### PR TITLE
docker log rotation; node-exporter for cfssl server

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -158,8 +158,12 @@ data "ignition_config" "cfssl" {
 
   systemd = ["${concat(
     list(
-        "${data.ignition_systemd_unit.cfssl.id}",
-        "${data.ignition_systemd_unit.cfssl-nginx.id}",
+        data.ignition_systemd_unit.update-engine.id,
+        data.ignition_systemd_unit.locksmithd.id,
+        data.ignition_systemd_unit.docker-opts-dropin.id,
+        data.ignition_systemd_unit.node-exporter.id,
+        data.ignition_systemd_unit.cfssl.id,
+        data.ignition_systemd_unit.cfssl-nginx.id,
     ),
     module.cfssl-restarter.systemd_units,
     module.cfssl-disk-mounter.systemd_units,

--- a/master.tf
+++ b/master.tf
@@ -192,6 +192,7 @@ data "ignition_config" "master" {
     list(
         data.ignition_systemd_unit.update-engine.id,
         data.ignition_systemd_unit.locksmithd.id,
+        data.ignition_systemd_unit.docker-opts-dropin.id,
         data.ignition_systemd_unit.master-kubelet.id,
     ),
     module.kubelet-restarter.systemd_units,

--- a/resources/docker-dropin.conf
+++ b/resources/docker-dropin.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=DOCKER_OPTS="--log-opt max-size=100m --log-opt max-file=1"

--- a/worker.tf
+++ b/worker.tf
@@ -116,6 +116,7 @@ data "ignition_config" "worker" {
     list(
         data.ignition_systemd_unit.update-engine.id,
         data.ignition_systemd_unit.locksmithd.id,
+        data.ignition_systemd_unit.docker-opts-dropin.id,
         data.ignition_systemd_unit.worker-kubelet.id,
     ),
     module.kubelet-restarter.systemd_units,


### PR DESCRIPTION
- docker systemd drop-in to enable log rotation options
- missing systemd units for cfssl
- node-exporter for cfssl