### PR TITLE
Allow parallel image pulls

### DIFF
--- a/resources/worker-kubelet.service
+++ b/resources/worker-kubelet.service
@@ -44,6 +44,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --eviction-soft-grace-period=memory.available=1m,nodefs.available=1m \
   --eviction-max-pod-grace-period=30 \
   --eviction-hard=memory.available<1Gi,nodefs.available<2Gi \
+  --serialize-image-pulls=false \
   --v=0
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 Restart=always


### PR DESCRIPTION
From https://kubernetes.io/docs/admin/kubelet/:

```
      --serialize-image-pulls
Pull images one at a time. We recommend *not* changing the default value on
nodes that run docker daemon with version < 1.9 or an Aufs storage backend.
Issue #10959 has more details. (default true)
```

Our production:

```
Server Version: 17.09.1-ce
Storage Driver: overlay2
```