### PR TITLE
Allow use of m5 instances 

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -38,9 +38,9 @@ data "ignition_file" "cfssl-client-config" {
 
 // used by the server
 module "cfssl-disk-mounter" {
-  source = "./systemd_disk_mounter"
+  source = "./systemd_disk_mounter_nvme"
 
-  device     = "xvdf"
+  volumeid   = "${var.cfssl_data_volumeid}"
   user       = "root"
   group      = "root"
   mountpoint = "/var/lib/cfssl"

--- a/systemd_disk_mounter_nvme/main.tf
+++ b/systemd_disk_mounter_nvme/main.tf
@@ -1,0 +1,54 @@
+variable "volumeid" {}
+variable "mountpoint" {}
+
+variable "user" {
+  default = "root"
+}
+
+variable "group" {
+  default = "root"
+}
+
+variable "filesystem" {
+  default = "ext4"
+}
+
+data "ignition_systemd_unit" "disk-formatter" {
+  name = "disk-formatter-${var.volumeid}.service"
+
+  content = <<EOS
+[Unit]
+Description=Format device with volume-id: ${var.volumeid}, if it has no filesystem
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=DEVICE=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_${var.volumeid}
+ExecStart=/bin/sh -c "fsck -a $${DEVICE} || (mkfs.${var.filesystem} $${DEVICE} && mount $${DEVICE} /mnt && chown -R ${var.user}:${var.group} /mnt && umount /mnt)"
+EOS
+}
+
+data "ignition_systemd_unit" "disk-mounter" {
+  name = "${join("-", compact(split("/", var.mountpoint)))}.mount"
+
+  content = <<EOS
+[Unit]
+Description=Mount device ${var.volumeid} to ${var.mountpoint}
+Requires=${data.ignition_systemd_unit.disk-formatter.name}
+After=${data.ignition_systemd_unit.disk-formatter.name}
+[Mount]
+What=/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_${var.volumeid}
+Where=${var.mountpoint}
+Type=${var.filesystem}
+EOS
+}
+
+output "systemd_units" {
+  value = [
+    "${data.ignition_systemd_unit.disk-formatter.id}",
+    "${data.ignition_systemd_unit.disk-mounter.id}",
+  ]
+}
+
+output "mount_unit_name" {
+  value = "${data.ignition_systemd_unit.disk-mounter.name}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -168,3 +168,5 @@ variable "cfssl_node_renew_timer" {
 variable "cfssl_server_address" {
   description = "The IP address of the cfssl server."
 }
+
+variable "cfssl_data_volumeid" {}


### PR DESCRIPTION
Introduces a new disk mounter module to handle nvme instances and disks.
Since the device name can no longer be specified in Terraform we need to
derive it from the volume id

We now pass in cfssl data volume id to module and find the device name
in /dev/disk/by-id/