### PR TITLE
Remove --service-account-private-key-file flag from kube-controller-m…

### DIFF
--- a/resources/kube-controller-manager.yaml
+++ b/resources/kube-controller-manager.yaml
@@ -15,7 +15,6 @@ spec:
     - --master=http://127.0.0.1:8080
     - --leader-elect=true
     - --use-service-account-credentials
-    - --service-account-private-key-file=/etc/kubernetes/ssl/signing-key.pem
     - --root-ca-file=/etc/kubernetes/ssl/ca.pem
     ${cloud_provider == "" ? "" : "- --cloud-provider=${cloud_provider}"}
     - --configure-cloud-routes=false


### PR DESCRIPTION
…anager

This PR suggest that the flag `--use-service-account-credentials` renders this flag obsolete
in PR #50289
And this PR is removing the flag completely in v1.11
https://github.com/kubernetes/kubernetes/pull/60875