### PR TITLE
Migrate kube-scheduler config from flags to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tf_kube_ignition
 
-This terraform module generates ignition configuration for Container Linux to help with the bootstrapping of kubernetes nodes. It requires at least Kubernetes v1.9
+This terraform module generates ignition configuration for Container Linux to help with the bootstrapping of kubernetes nodes. It requires at least Kubernetes v1.9.
 
 ## Input Variables
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tf_kube_ignition
 
-This terraform module generates ignition configuration for Container Linux to help with the bootstrapping of kubernetes nodes.
+This terraform module generates ignition configuration for Container Linux to help with the bootstrapping of kubernetes nodes. It requires at least Kubernetes v1.9
 
 ## Input Variables
 

--- a/master.tf
+++ b/master.tf
@@ -74,6 +74,16 @@ data "ignition_systemd_unit" "master-kubelet" {
 data "ignition_file" "master-kubeconfig" {
   mode       = 0644
   filesystem = "root"
+  path       = "/etc/kubernetes/config/master-kubeconfig"
+
+  content {
+    content = "${file("${path.module}/resources/master-kubeconfig")}"
+  }
+}
+
+data "ignition_file" "kubelet-kubeconfig" {
+  mode       = 0644
+  filesystem = "root"
   path       = "/var/lib/kubelet/kubeconfig"
 
   content {
@@ -159,7 +169,7 @@ data "ignition_file" "kube-scheduler" {
 data "ignition_file" "kube-scheduler-config" {
   mode       = 0644
   filesystem = "root"
-  path       = "/etc/kubernetes/configs/kube-scheduler-config.yaml"
+  path       = "/etc/kubernetes/config/kube-scheduler-config.yaml"
 
   content {
     content = "${file("${path.module}/resources/kube-scheduler-config.yaml")}"
@@ -186,6 +196,7 @@ data "ignition_config" "master" {
         data.ignition_file.master-cfssl-sk-get.id,
         data.ignition_file.master-prom-machine-role.id,
         data.ignition_file.master-kubeconfig.id,
+        data.ignition_file.kubelet-kubeconfig.id,
         data.ignition_file.kube-apiserver.id,
         data.ignition_file.kube-scheduler.id,
         data.ignition_file.kube-scheduler-config.id,

--- a/master.tf
+++ b/master.tf
@@ -156,6 +156,16 @@ data "ignition_file" "kube-scheduler" {
   }
 }
 
+data "ignition_file" "kube-scheduler-config" {
+  mode       = 0644
+  filesystem = "root"
+  path       = "/etc/kubernetes/configs/kube-scheduler-config.yaml"
+
+  content {
+    content = "${file("${path.module}/resources/kube-scheduler-config.yaml")}"
+  }
+}
+
 data "ignition_file" "master-prom-machine-role" {
   mode       = 0644
   filesystem = "root"
@@ -178,6 +188,7 @@ data "ignition_config" "master" {
         data.ignition_file.master-kubeconfig.id,
         data.ignition_file.kube-apiserver.id,
         data.ignition_file.kube-scheduler.id,
+        data.ignition_file.kube-scheduler-config.id,
         data.ignition_file.kube-controller-manager.id,
     ),
     var.master_additional_files,

--- a/resources/kube-scheduler-config.yaml
+++ b/resources/kube-scheduler-config.yaml
@@ -1,6 +1,6 @@
 kind: KubeSchedulerConfiguration
 apiVersion: componentconfig/v1alpha1
 clientConnection:
-  kubeconfig: /var/lib/kubelet/kubeconfig
+  kubeconfig: /etc/kubernetes/config/master-kubeconfig
 leaderElection:
   leaderElect: true

--- a/resources/kube-scheduler-config.yaml
+++ b/resources/kube-scheduler-config.yaml
@@ -1,0 +1,6 @@
+kind: KubeSchedulerConfiguration
+apiVersion: componentconfig/v1alpha1
+clientConnection:
+  kubeconfig: /var/lib/kubelet/kubeconfig
+leaderElection:
+  leaderElect: true

--- a/resources/kube-scheduler.yaml
+++ b/resources/kube-scheduler.yaml
@@ -13,7 +13,7 @@ spec:
     command:
     - /hyperkube
     - scheduler
-    - --config=/etc/kubernetes/configs/kube-scheduler-config.yaml
+    - --config=/etc/kubernetes/config/kube-scheduler-config.yaml
     - --v=0
     livenessProbe:
       httpGet:
@@ -23,21 +23,10 @@ spec:
       initialDelaySeconds: 15
       timeoutSeconds: 15
     volumeMounts:
-    - mountPath: /etc/kubernetes/ssl
-      name: ssl-certs-kubernetes
-      readOnly: true
-    - mountPath: /etc/kubernetes/configs
+    - mountPath: /etc/kubernetes/config
       name: kubernetes-configurations
       readOnly: true
-    - mountPath: /var/lib/kubelet
-      name: kubelet-files
   volumes:
   - hostPath:
-      path: /etc/kubernetes/ssl
-    name: ssl-certs-kubernetes
-  - hostPath:
-      path: /etc/kubernetes/configs
+      path: /etc/kubernetes/config
     name: kubernetes-configurations
-  - hostPath:
-      path: /var/lib/kubelet
-    name: kubelet-files

--- a/resources/kube-scheduler.yaml
+++ b/resources/kube-scheduler.yaml
@@ -13,8 +13,7 @@ spec:
     command:
     - /hyperkube
     - scheduler
-    - --master=http://127.0.0.1:8080
-    - --leader-elect=true
+    - --config=/etc/kubernetes/configs/kube-scheduler-config.yaml
     - --v=0
     livenessProbe:
       httpGet:
@@ -23,3 +22,22 @@ spec:
         port: 10251
       initialDelaySeconds: 15
       timeoutSeconds: 15
+    volumeMounts:
+    - mountPath: /etc/kubernetes/ssl
+      name: ssl-certs-kubernetes
+      readOnly: true
+    - mountPath: /etc/kubernetes/configs
+      name: kubernetes-configurations
+      readOnly: true
+    - mountPath: /var/lib/kubelet
+      name: kubelet-files
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: ssl-certs-kubernetes
+  - hostPath:
+      path: /etc/kubernetes/configs
+    name: kubernetes-configurations
+  - hostPath:
+      path: /var/lib/kubelet
+    name: kubelet-files

--- a/resources/master-kubeconfig
+++ b/resources/master-kubeconfig
@@ -3,16 +3,12 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    certificate-authority: /etc/kubernetes/ssl/ca.pem
     server: http://127.0.0.1:8080
 users:
-- name: kubelet
-  user:
-    client-certificate: /etc/kubernetes/ssl/node.pem
-    client-key: /etc/kubernetes/ssl/node-key.pem
+- name: master-component
 contexts:
 - context:
     cluster: local
-    user: kubelet
+    user: master-component
   name: kubelet-cluster.local
 current-context: kubelet-cluster.local


### PR DESCRIPTION
What do you think about using `/var/lib/kubelet/kubeconfig`? I am thinking on moving the file to `/etc/kubernetes/configs`, or maybe duplicate it. Thoughts?