### PR TITLE
Add node-role label to masters

### DIFF
--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -31,7 +31,7 @@ ExecStartPre=-/bin/sh -c "docker restart $(docker ps --no-trunc | grep 'kube-api
 ExecStartPre=-/usr/bin/rkt gc --grace-period=0s
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --kubeconfig=/var/lib/kubelet/kubeconfig \
-  --node-labels=role=master \
+  --node-labels=role=master,node-role.kubernetes.io/master="" \
   --register-node=true \
   --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
   --container-runtime=docker \


### PR DESCRIPTION
Taint out masters, this stops things like `Service` with `type:
LoadBalancer` from opening NodePorts on masters and registering them wih
target pools