### PR TITLE
sys: kube upgrade

### DIFF
--- a/resources/kube-apiserver.yaml
+++ b/resources/kube-apiserver.yaml
@@ -19,7 +19,7 @@ spec:
     - --allow-privileged=true
     - --service-cluster-ip-range=${service_network}
     - --secure-port=443
-    - --admission-control=NodeRestriction,NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize
+    - --enable-admission-plugins=NodeRestriction,NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize
     - --feature-gates=ExpandPersistentVolumes=true
     - --tls-cert-file=/etc/kubernetes/ssl/node.pem
     - --tls-private-key-file=/etc/kubernetes/ssl/node-key.pem

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "hyperkube_image_url" {
 
 variable "hyperkube_image_tag" {
   description = "The version of the hyperkube image to use."
-  default     = "v1.11.0"
+  default     = "v1.11.1"
 }
 
 variable "cluster_dns" {


### PR DESCRIPTION
 - kube version 1.11.1
 - deprecated `admission-control` flag for `enable-admission-plugins`