### PR TITLE
Etcd cert reload

### DIFF
--- a/cert-fetcher/main.tf
+++ b/cert-fetcher/main.tf
@@ -1,0 +1,36 @@
+variable "on_calendar" {}
+variable "service_name" {}
+
+data "ignition_systemd_unit" "cert-fetch-service" {
+  name = "cert-fetch.service"
+
+  content = <<EOS
+[Unit]
+Description=Fetch new certificates from cfssl server
+[Service]
+Type=oneshot
+ExecStart=/opt/bin/cfssl-new-cert
+EOS
+}
+
+data "ignition_systemd_unit" "cert-fetch-timer" {
+  name = "cert-fetch.timer"
+
+  content = <<EOS
+[Unit]
+Description=Fetch new certificates from cfssl server
+[Timer]
+OnCalendar=${var.on_calendar}
+AccuracySec=1s
+RandomizedDelaySec=60min
+[Install]
+WantedBy=timers.target
+EOS
+}
+
+output "systemd_units" {
+  value = [
+    "${data.ignition_systemd_unit.cert-fetch-service.id}",
+    "${data.ignition_systemd_unit.cert-fetch-timer.id}",
+  ]
+}

--- a/cert-fetcher/main.tf
+++ b/cert-fetcher/main.tf
@@ -1,5 +1,4 @@
 variable "on_calendar" {}
-variable "service_name" {}
 
 data "ignition_systemd_unit" "cert-fetch-service" {
   name = "cert-fetch.service"

--- a/cert-fetcher/main.tf
+++ b/cert-fetcher/main.tf
@@ -9,6 +9,8 @@ Description=Fetch new certificates from cfssl server
 [Service]
 Type=oneshot
 ExecStart=/opt/bin/cfssl-new-cert
+[Install]
+WantedBy=multi-user.target
 EOS
 }
 

--- a/etcd.tf
+++ b/etcd.tf
@@ -118,6 +118,12 @@ data "ignition_systemd_unit" "etcd-member-dropin" {
   }
 }
 
+module "etcd-cert-fetcher" {
+  source = "./cert-fetcher"
+
+  on_calendar = "${var.cfssl_node_renew_timer}"
+}
+
 data "ignition_config" "etcd" {
   count = "${length(var.etcd_addresses)}"
 
@@ -143,6 +149,7 @@ data "ignition_config" "etcd" {
         element(data.ignition_systemd_unit.etcd-member-dropin.*.id, count.index),
         element(data.ignition_systemd_unit.etcd-disk-mounter.*.id, count.index),
     ),
+		module.etcd-cert-fetcher.systemd_units,
     var.etcd_additional_systemd_units,
   )}"]
 }

--- a/etcd.tf
+++ b/etcd.tf
@@ -149,7 +149,7 @@ data "ignition_config" "etcd" {
         element(data.ignition_systemd_unit.etcd-member-dropin.*.id, count.index),
         element(data.ignition_systemd_unit.etcd-disk-mounter.*.id, count.index),
     ),
-		module.etcd-cert-fetcher.systemd_units,
+    module.etcd-cert-fetcher.systemd_units,
     var.etcd_additional_systemd_units,
   )}"]
 }

--- a/etcd.tf
+++ b/etcd.tf
@@ -118,13 +118,6 @@ data "ignition_systemd_unit" "etcd-member-dropin" {
   }
 }
 
-module "etcd-member-restarter" {
-  source = "./systemd_service_restarter"
-
-  service_name = "etcd-member"
-  on_calendar  = "${var.cfssl_node_renew_timer}"
-}
-
 data "ignition_config" "etcd" {
   count = "${length(var.etcd_addresses)}"
 
@@ -150,7 +143,6 @@ data "ignition_config" "etcd" {
         element(data.ignition_systemd_unit.etcd-member-dropin.*.id, count.index),
         element(data.ignition_systemd_unit.etcd-disk-mounter.*.id, count.index),
     ),
-    module.etcd-member-restarter.systemd_units,
     var.etcd_additional_systemd_units,
   )}"]
 }

--- a/resources/etcd-member-dropin.conf
+++ b/resources/etcd-member-dropin.conf
@@ -24,4 +24,3 @@ Environment="RKT_RUN_ARGS=\
   --volume etc-etcd,kind=host,source=/etc/etcd,readOnly=true \
   --mount volume=etc-etcd,target=/etc/etcd"
 ExecStartPre=/usr/bin/mkdir -p /etc/etcd
-ExecStartPre=/opt/bin/cfssl-new-cert


### PR DESCRIPTION
We no longer need to restart etcd service to reload certificates, it can reload from disk.

Remove the services that restart etcd and the ExecStartPre step to get new certificates. Create a new service with a timer to get the certificates, separate to etcd itself.