### PR TITLE
Add PodPreset admission plugin

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -112,8 +112,9 @@ data "template_file" "kube-apiserver" {
      *   https://github.com/kubernetes/kubernetes/blob/<ref>/pkg/master/master.go
      *
      */
-
-    runtime_config = "${join(",", list())}"
+    runtime_config = "${join(",", list(
+      "settings.k8s.io/v1alpha1=true",
+    ))}"
   }
 }
 

--- a/resources/kube-apiserver.yaml
+++ b/resources/kube-apiserver.yaml
@@ -19,7 +19,7 @@ spec:
     - --allow-privileged=true
     - --service-cluster-ip-range=${service_network}
     - --secure-port=443
-    - --enable-admission-plugins=NodeRestriction,NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize
+    - --enable-admission-plugins=NodeRestriction,NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,PersistentVolumeClaimResize,PodPreset
     - --feature-gates=ExpandPersistentVolumes=true
     - --tls-cert-file=/etc/kubernetes/ssl/node.pem
     - --tls-private-key-file=/etc/kubernetes/ssl/node-key.pem


### PR DESCRIPTION
We want to test PodPresets to inject tracing env vars in telco 

https://kubernetes.io/docs/concepts/workloads/pods/podpreset/#enable-pod-preset

Not sure whether this will work as PodPresets require `settings.k8s.io/v1alpha1=true` in `--runtime_config`