### PR TITLE
Kubelet certs

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -12,7 +12,7 @@ data "template_file" "master-cfssl-new-cert" {
     profile = "client-server"
     path    = "/etc/kubernetes/ssl"
     cn      = "system:node:$(${var.node_name_command[var.cloud_provider]})"
-    org     = "system:nodes"
+    org     = "system:masters"
     get_ip  = "${var.get_ip_command[var.cloud_provider]}"
 
     extra_names = "${join(",", list(

--- a/resources/kube-apiserver.yaml
+++ b/resources/kube-apiserver.yaml
@@ -44,6 +44,8 @@ spec:
     - --requestheader-username-headers=X-Remote-User
     - --proxy-client-cert-file=/etc/kubernetes/ssl/proxy.pem
     - --proxy-client-key-file=/etc/kubernetes/ssl/proxy-key.pem
+    - --kubelet-client-certificate=/etc/kubernetes/ssl/node.pem
+    - --kubelet-client-key=/etc/kubernetes/ssl/node-key.pem
     - --v=0
     livenessProbe:
       httpGet:

--- a/resources/master-kubelet-conf.yaml
+++ b/resources/master-kubelet-conf.yaml
@@ -5,6 +5,8 @@ authentication:
     enabled: true
   webhook:
     enabled: false
+  x509:
+    clientCAFile: "/etc/kubernetes/ssl/ca.pem"
 authorization:
   mode: AlwaysAllow
 clusterDNS:

--- a/resources/master-kubelet-conf.yaml
+++ b/resources/master-kubelet-conf.yaml
@@ -4,5 +4,6 @@ clusterDNS:
   - "${cluster_dns}"
 clusterDomain: "cluster.local"
 ${feature_gates == "" ? "" : "featureGates:\n  ${feature_gates}"}
+readOnlyPort: 10255
 serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"

--- a/resources/master-kubelet-conf.yaml
+++ b/resources/master-kubelet-conf.yaml
@@ -1,5 +1,12 @@
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
 clusterDNS:
   - "${cluster_dns}"
 clusterDomain: "cluster.local"

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -40,6 +40,7 @@ ExecStart=/usr/bin/docker \
     --entrypoint /usr/local/bin/kubelet \
   "${kubelet_image_url}:${kubelet_image_tag}" \
     --allow-privileged \
+    --client-ca-file=/etc/kubernetes/ssl/ca.pem \
     --config=/etc/kubernetes/config/master-kubelet-conf.yaml \
     --kubeconfig=/var/lib/kubelet/kubeconfig \
     --node-labels=role=master,node-role.kubernetes.io/master="" \

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -40,6 +40,8 @@ ExecStart=/usr/bin/docker \
     --entrypoint /usr/local/bin/kubelet \
   "${kubelet_image_url}:${kubelet_image_tag}" \
     --allow-privileged \
+    --anonymous-auth \
+    --authorization-mode="AlwaysAllow" \
     --client-ca-file=/etc/kubernetes/ssl/ca.pem \
     --config=/etc/kubernetes/config/master-kubelet-conf.yaml \
     --kubeconfig=/var/lib/kubelet/kubeconfig \

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -40,8 +40,6 @@ ExecStart=/usr/bin/docker \
     --entrypoint /usr/local/bin/kubelet \
   "${kubelet_image_url}:${kubelet_image_tag}" \
     --allow-privileged \
-    --anonymous-auth \
-    --authorization-mode="AlwaysAllow" \
     --client-ca-file=/etc/kubernetes/ssl/ca.pem \
     --config=/etc/kubernetes/config/master-kubelet-conf.yaml \
     --kubeconfig=/var/lib/kubelet/kubeconfig \

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -40,7 +40,6 @@ ExecStart=/usr/bin/docker \
     --entrypoint /usr/local/bin/kubelet \
   "${kubelet_image_url}:${kubelet_image_tag}" \
     --allow-privileged \
-    --client-ca-file=/etc/kubernetes/ssl/ca.pem \
     --config=/etc/kubernetes/config/master-kubelet-conf.yaml \
     --kubeconfig=/var/lib/kubelet/kubeconfig \
     --node-labels=role=master,node-role.kubernetes.io/master="" \

--- a/resources/worker-kubelet-conf.yaml
+++ b/resources/worker-kubelet-conf.yaml
@@ -5,6 +5,8 @@ authentication:
     enabled: true
   webhook:
     enabled: false
+  x509:
+    clientCAFile: "/etc/kubernetes/ssl/ca.pem"
 authorization:
   mode: AlwaysAllow
 clusterDNS:

--- a/resources/worker-kubelet-conf.yaml
+++ b/resources/worker-kubelet-conf.yaml
@@ -14,5 +14,6 @@ evictionSoftGracePeriod:
   memory.available: "1m"
   nodefs.available: "1m"
 ${feature_gates == "" ? "" : "featureGates:\n  ${feature_gates}"}
+readOnlyPort: 10255
 serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"

--- a/resources/worker-kubelet-conf.yaml
+++ b/resources/worker-kubelet-conf.yaml
@@ -1,5 +1,12 @@
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    enabled: false
+authorization:
+  mode: AlwaysAllow
 clusterDNS:
   - "${cluster_dns}"
 clusterDomain: "cluster.local"

--- a/resources/worker-kubelet.service
+++ b/resources/worker-kubelet.service
@@ -39,8 +39,6 @@ ExecStart=/usr/bin/docker \
     --entrypoint /usr/local/bin/kubelet \
   "${kubelet_image_url}:${kubelet_image_tag}" \
     --allow-privileged \
-    --anonymous-auth \
-    --authorization-mode="AlwaysAllow" \
     --client-ca-file=/etc/kubernetes/ssl/ca.pem \
     ${cloud_provider == "" ? "" : "--cloud-provider=${cloud_provider}"} \
     --cni-bin-dir=/opt/cni/bin \

--- a/resources/worker-kubelet.service
+++ b/resources/worker-kubelet.service
@@ -39,16 +39,17 @@ ExecStart=/usr/bin/docker \
     --entrypoint /usr/local/bin/kubelet \
   "${kubelet_image_url}:${kubelet_image_tag}" \
     --allow-privileged \
-    --config=/etc/kubernetes/config/master-kubelet-conf.yaml \
-    --kubeconfig=/var/lib/kubelet/kubeconfig \
-    --node-labels=role=${role} \
-    --container-runtime=docker \
-    --network-plugin=cni \
+    --client-ca-file=/etc/kubernetes/ssl/ca.pem \
+    ${cloud_provider == "" ? "" : "--cloud-provider=${cloud_provider}"} \
     --cni-bin-dir=/opt/cni/bin \
     --cni-conf-dir=/etc/cni/net.d \
-    ${cloud_provider == "" ? "" : "--cloud-provider=${cloud_provider}"} \
-    --lock-file=/var/run/lock/kubelet.lock \
+    --config=/etc/kubernetes/config/master-kubelet-conf.yaml \
+    --container-runtime=docker \
     --exit-on-lock-contention \
+    --kubeconfig=/var/lib/kubelet/kubeconfig \
+    --network-plugin=cni \
+    --node-labels=role=${role} \
+    --lock-file=/var/run/lock/kubelet.lock \
     --v=0
 Restart=always
 RestartSec=10

--- a/resources/worker-kubelet.service
+++ b/resources/worker-kubelet.service
@@ -43,7 +43,7 @@ ExecStart=/usr/bin/docker \
     ${cloud_provider == "" ? "" : "--cloud-provider=${cloud_provider}"} \
     --cni-bin-dir=/opt/cni/bin \
     --cni-conf-dir=/etc/cni/net.d \
-    --config=/etc/kubernetes/config/master-kubelet-conf.yaml \
+    --config=/etc/kubernetes/config/worker-kubelet-conf.yaml \
     --container-runtime=docker \
     --exit-on-lock-contention \
     --kubeconfig=/var/lib/kubelet/kubeconfig \

--- a/resources/worker-kubelet.service
+++ b/resources/worker-kubelet.service
@@ -39,7 +39,6 @@ ExecStart=/usr/bin/docker \
     --entrypoint /usr/local/bin/kubelet \
   "${kubelet_image_url}:${kubelet_image_tag}" \
     --allow-privileged \
-    --client-ca-file=/etc/kubernetes/ssl/ca.pem \
     ${cloud_provider == "" ? "" : "--cloud-provider=${cloud_provider}"} \
     --cni-bin-dir=/opt/cni/bin \
     --cni-conf-dir=/etc/cni/net.d \

--- a/resources/worker-kubelet.service
+++ b/resources/worker-kubelet.service
@@ -39,6 +39,8 @@ ExecStart=/usr/bin/docker \
     --entrypoint /usr/local/bin/kubelet \
   "${kubelet_image_url}:${kubelet_image_tag}" \
     --allow-privileged \
+    --anonymous-auth \
+    --authorization-mode="AlwaysAllow" \
     --client-ca-file=/etc/kubernetes/ssl/ca.pem \
     ${cloud_provider == "" ? "" : "--cloud-provider=${cloud_provider}"} \
     --cni-bin-dir=/opt/cni/bin \

--- a/variables.tf
+++ b/variables.tf
@@ -203,7 +203,7 @@ locals {
   #   PodShareProcessNamespace: true
   # ```
   #
-  # note the two white space at the start of the line, this corresponds to the
+  # note the two white space chars at the start of the line, this corresponds to the
   # formatting in worker-kubelet-conf.yaml and master-kubelet-conf.yaml
   feature_gates_yaml_fragment = "${join("\n  ", formatlist("%s: %s", keys(var.feature_gates), values(var.feature_gates)))}"
 }

--- a/worker.tf
+++ b/worker.tf
@@ -111,7 +111,7 @@ data "ignition_config" "worker" {
         data.ignition_file.worker-prom-machine-role.id,
         data.ignition_file.worker-kubeconfig.id,
         data.ignition_file.worker-sysctl-vm.id,
-        data.ignition_file.master-kubelet-conf.id,
+        data.ignition_file.worker-kubelet-conf.id,
     ),
     var.worker_additional_files
   )}"]


### PR DESCRIPTION
Differences in kubelet config:

```
+      "x509": {
+        "clientCAFile": "/etc/kubernetes/ssl/ca.pem"
+      },
```

and

```
+    "featureGates": {
+      "AdvancedAuditing": false,
+      "ExpandPersistentVolumes": true,
+      "PodShareProcessNamespace": true
+    },
```

And the only warning we get from kubelet logs is:

```
Oct 03 14:57:41 ip-10-66-23-108 docker[1252]: Flag --allow-privileged has been deprecated, will be removed in a future version
```

which we can't do anything about currently: https://trello.com/c/LtXvyQuZ/486-remove-allow-privileged-from-kubelet