### PR TITLE
sys: Retry certificate fetching

### DIFF
--- a/cert-fetcher/main.tf
+++ b/cert-fetcher/main.tf
@@ -8,7 +8,7 @@ data "ignition_systemd_unit" "cert-fetch-service" {
 Description=Fetch new certificates from cfssl server
 [Service]
 Type=oneshot
-ExecStart=/opt/bin/cfssl-new-cert
+ExecStart=/bin/sh -c 'while ! /opt/bin/cfssl-new-cert; do echo "cfssl not ready, sleeping 5 seconds";sleep 5; done'
 [Install]
 WantedBy=multi-user.target
 EOS


### PR DESCRIPTION
This change only affects etcds.

Systemd doesn't support `Restart` on `oneshot` units yet. This works fine in exp-2. Output of etcd retrying while cfssl is down (`journaltcl -u cert-fetch`):

```Dec 04 16:38:35 ip-10-66-25-4 sh[910]: cfssl not ready, sleeping 5 seconds
Dec 04 16:38:40 ip-10-66-25-4 sh[910]: 2018/12/04 16:38:40 [INFO] generate received request
Dec 04 16:38:40 ip-10-66-25-4 sh[910]: 2018/12/04 16:38:40 [INFO] received CSR
Dec 04 16:38:40 ip-10-66-25-4 sh[910]: 2018/12/04 16:38:40 [INFO] generating key: ecdsa-384
Dec 04 16:38:40 ip-10-66-25-4 sh[910]: 2018/12/04 16:38:40 [INFO] encoded CSR
Dec 04 16:38:40 ip-10-66-25-4 sh[910]: {"code":7400,"message":"Post http://10.66.25.5:8888/api/v1/cfssl/authsign: dial tcp 10.66.25.5:8888: getsockopt: connection refused"}
Dec 04 16:38:40 ip-10-66-25-4 sh[910]: Failed to parse input: unexpected end of JSON input
Dec 04 16:38:40 ip-10-66-25-4 sh[910]: cfssl not ready, sleeping 5 seconds
Dec 04 16:38:45 ip-10-66-25-4 sh[910]: 2018/12/04 16:38:45 [INFO] generate received request
Dec 04 16:38:45 ip-10-66-25-4 sh[910]: 2018/12/04 16:38:45 [INFO] received CSR
Dec 04 16:38:45 ip-10-66-25-4 sh[910]: 2018/12/04 16:38:45 [INFO] generating key: ecdsa-384
Dec 04 16:38:45 ip-10-66-25-4 sh[910]: 2018/12/04 16:38:45 [INFO] encoded CSR
Dec 04 16:38:45 ip-10-66-25-4 systemd[1]: Started Fetch new certificates from cfssl server.```