### PR TITLE
Kubelet vuln

### DIFF
--- a/resources/master-kubelet-conf.yaml
+++ b/resources/master-kubelet-conf.yaml
@@ -2,7 +2,7 @@ kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
 authentication:
   anonymous:
-    enabled: true
+    enabled: false
   webhook:
     enabled: false
   x509:

--- a/resources/master-kubelet-conf.yaml
+++ b/resources/master-kubelet-conf.yaml
@@ -13,6 +13,5 @@ clusterDNS:
   - "${cluster_dns}"
 clusterDomain: "cluster.local"
 ${feature_gates == "" ? "" : "featureGates:\n  ${feature_gates}"}
-readOnlyPort: 10255
 serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"

--- a/resources/worker-kubelet-conf.yaml
+++ b/resources/worker-kubelet-conf.yaml
@@ -23,6 +23,5 @@ evictionSoftGracePeriod:
   memory.available: "1m"
   nodefs.available: "1m"
 ${feature_gates == "" ? "" : "featureGates:\n  ${feature_gates}"}
-readOnlyPort: 10255
 serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"

--- a/resources/worker-kubelet-conf.yaml
+++ b/resources/worker-kubelet-conf.yaml
@@ -2,7 +2,7 @@ kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1
 authentication:
   anonymous:
-    enabled: true
+    enabled: false
   webhook:
     enabled: false
   x509:


### PR DESCRIPTION
```
kubernetes-manifests(master) 18:32:25 $ kubectl --context=exp-1-aws -n kube-system exec -ti kube-applier-699cc968bf-v27c5 -- ash
Defaulting container name to kube-applier.
Use 'kubectl describe pod/kube-applier-699cc968bf-v27c5 -n kube-system' to see all of the containers in this pod.
/ # curl --insecure  https://10.2.10.1:10250/pods
ash: curl: not found
/ # apk --no-cache add curl
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
(1/1) Installing curl (7.61.1-r1)
Executing busybox-1.28.4-r1.trigger
OK: 19 MiB in 21 packages
/ # curl --insecure  https://10.2.10.1:10250/pods
Unauthorized/ #
```