### PR TITLE
Sort apiserver certificates according to kube docs.

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -8,13 +8,14 @@ data "template_file" "etcd-cfssl-new-cert" {
   template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
 
   vars {
-    user    = "etcd"
-    group   = "etcd"
-    profile = "client-server"
-    path    = "/etc/etcd/ssl"
-    cn      = "${count.index}.etcd.${var.dns_domain}"
-    org     = ""
-    get_ip  = "${var.get_ip_command[var.cloud_provider]}"
+    cert_name = "node"
+    user      = "etcd"
+    group     = "etcd"
+    profile   = "client-server"
+    path      = "/etc/etcd/ssl"
+    cn        = "${count.index}.etcd.${var.dns_domain}"
+    org       = ""
+    get_ip    = "${var.get_ip_command[var.cloud_provider]}"
 
     extra_names = "${join(",", list(
       "etcd.${var.dns_domain}",

--- a/master.tf
+++ b/master.tf
@@ -3,10 +3,11 @@ data "ignition_systemd_unit" "locksmithd_master" {
   mask = "${!var.enable_container_linux_locksmithd_master}"
 }
 
-// Node certificate for kubelet to use as part of system:master-nodes. We need ClusterRoleBindings to allow kube components creation
-// and bind the group with system:node role.
-// In order to be authorized by the Node authorizer, kubelets must use a credential that identifies them as being in 
-// the system:nodes group, with a username of system:node:<nodeName>
+// Node certificate for kubelet to use as part of system:master-nodes. We need
+// ClusterRoleBindings to allow kube components creation and bind the group
+// with system:node role. In order to be authorized by the Node authorizer,
+// kubelets must use a credential that identifies them as being in the
+// system:nodes group, with a username of system:node:<nodeName>
 data "template_file" "master-node-cfssl-new-cert" {
   template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
 

--- a/master.tf
+++ b/master.tf
@@ -3,17 +3,50 @@ data "ignition_systemd_unit" "locksmithd_master" {
   mask = "${!var.enable_container_linux_locksmithd_master}"
 }
 
-data "template_file" "master-cfssl-new-cert" {
+// Node certificate for kubelet to use as part of system:master-nodes. We need ClusterRoleBindings to allow kube components creation
+// and bind the group with system:node role.
+// In order to be authorized by the Node authorizer, kubelets must use a credential that identifies them as being in 
+// the system:nodes group, with a username of system:node:<nodeName>
+data "template_file" "master-node-cfssl-new-cert" {
   template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
 
   vars {
-    user    = "root"
-    group   = "root"
-    profile = "client-server"
-    path    = "/etc/kubernetes/ssl"
-    cn      = "system:node:$(${var.node_name_command[var.cloud_provider]})"
-    org     = "system:masters"
-    get_ip  = "${var.get_ip_command[var.cloud_provider]}"
+    cert_name = "node"
+    user      = "root"
+    group     = "root"
+    profile   = "client-server"
+    path      = "/etc/kubernetes/ssl"
+    cn        = "system:node:$(${var.node_name_command[var.cloud_provider]})"
+    org       = "system:master-nodes"
+    get_ip    = "${var.get_ip_command[var.cloud_provider]}"
+
+    extra_names = "localhost"
+  }
+}
+
+data "ignition_file" "master-cfssl-new-node-cert" {
+  mode       = 0755
+  filesystem = "root"
+  path       = "/opt/bin/cfssl-new-node-cert"
+
+  content {
+    content = "${data.template_file.master-node-cfssl-new-cert.rendered}"
+  }
+}
+
+// Serving certificate for the API server
+data "template_file" "master-apiserver-cfssl-new-cert" {
+  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+
+  vars {
+    cert_name = "apiserver"
+    user      = "root"
+    group     = "root"
+    profile   = "client-server"
+    path      = "/etc/kubernetes/ssl"
+    cn        = "system:node:$(${var.node_name_command[var.cloud_provider]})"
+    org       = ""
+    get_ip    = "${var.get_ip_command[var.cloud_provider]}"
 
     extra_names = "${join(",", list(
       "${var.kubernetes_master_default_svc[var.cloud_provider]}",
@@ -23,17 +56,99 @@ data "template_file" "master-cfssl-new-cert" {
       "kubernetes.default.svc.cluster.local",
       "elb.master.${var.dns_domain}",
       "*.master.${var.dns_domain}",
+      "localhost",
     ))}"
   }
 }
 
-data "ignition_file" "master-cfssl-new-cert" {
+data "ignition_file" "master-cfssl-new-apiserver-cert" {
   mode       = 0755
   filesystem = "root"
-  path       = "/opt/bin/cfssl-new-cert"
+  path       = "/opt/bin/cfssl-new-apiserver-cert"
 
   content {
-    content = "${data.template_file.master-cfssl-new-cert.rendered}"
+    content = "${data.template_file.master-apiserver-cfssl-new-cert.rendered}"
+  }
+}
+
+// Client certificate for the API server to connect to the kubelets securely
+data "template_file" "master-apiserver-kubelet-client-cfssl-new-cert" {
+  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+
+  vars {
+    cert_name   = "apiserver-kubelet-client"
+    user        = "root"
+    group       = "root"
+    profile     = "client-server"
+    path        = "/etc/kubernetes/ssl"
+    cn          = "system:node:$(${var.node_name_command[var.cloud_provider]})"
+    org         = "system:masters"
+    get_ip      = "${var.get_ip_command[var.cloud_provider]}"
+    extra_names = "localhost"
+  }
+}
+
+data "ignition_file" "master-cfssl-new-apiserver-kubelet-client-cert" {
+  mode       = 0755
+  filesystem = "root"
+  path       = "/opt/bin/cfssl-new-apiserver-kubelet-client-cert"
+
+  content {
+    content = "${data.template_file.master-apiserver-kubelet-client-cfssl-new-cert.rendered}"
+  }
+}
+
+// Client certificate for kube-scheduler
+data "template_file" "master-scheduler-cfssl-new-cert" {
+  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+
+  vars {
+    cert_name   = "scheduler"
+    user        = "root"
+    group       = "root"
+    profile     = "client-server"
+    path        = "/etc/kubernetes/ssl"
+    cn          = "system:kube-scheduler"
+    org         = ""
+    get_ip      = "${var.get_ip_command[var.cloud_provider]}"
+    extra_names = "localhost"
+  }
+}
+
+data "ignition_file" "master-cfssl-new-scheduler-cert" {
+  mode       = 0755
+  filesystem = "root"
+  path       = "/opt/bin/cfssl-new-scheduler-cert"
+
+  content {
+    content = "${data.template_file.master-scheduler-cfssl-new-cert.rendered}"
+  }
+}
+
+// Client certificate for kube-controller-manager
+data "template_file" "master-controller-manager-cfssl-new-cert" {
+  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+
+  vars {
+    cert_name   = "controller-manager"
+    user        = "root"
+    group       = "root"
+    profile     = "client-server"
+    path        = "/etc/kubernetes/ssl"
+    cn          = "system:kube-controller-manager"
+    org         = ""
+    get_ip      = "${var.get_ip_command[var.cloud_provider]}"
+    extra_names = "localhost"
+  }
+}
+
+data "ignition_file" "master-cfssl-new-controller-manager-cert" {
+  mode       = 0755
+  filesystem = "root"
+  path       = "/opt/bin/cfssl-new-controller-manager-cert"
+
+  content {
+    content = "${data.template_file.master-controller-manager-cfssl-new-cert.rendered}"
   }
 }
 
@@ -90,13 +205,21 @@ data "ignition_file" "master-kubelet-conf" {
   }
 }
 
+data "template_file" "master-kubeconfig" {
+  template = "${file("${path.module}/resources/master-kubeconfig")}"
+
+  vars {
+    master_address = "localhost:443"
+  }
+}
+
 data "ignition_file" "master-kubeconfig" {
   mode       = 0644
   filesystem = "root"
   path       = "/etc/kubernetes/config/master-kubeconfig"
 
   content {
-    content = "${file("${path.module}/resources/master-kubeconfig")}"
+    content = "${data.template_file.master-kubeconfig.rendered}"
   }
 }
 
@@ -106,7 +229,43 @@ data "ignition_file" "kubelet-kubeconfig" {
   path       = "/var/lib/kubelet/kubeconfig"
 
   content {
-    content = "${file("${path.module}/resources/master-kubeconfig")}"
+    content = "${data.template_file.master-kubeconfig.rendered}"
+  }
+}
+
+data "template_file" "scheduler-kubeconfig" {
+  template = "${file("${path.module}/resources/scheduler-kubeconfig")}"
+
+  vars {
+    master_address = "localhost:443"
+  }
+}
+
+data "ignition_file" "scheduler-kubeconfig" {
+  mode       = 0644
+  filesystem = "root"
+  path       = "/etc/kubernetes/config/scheduler.conf"
+
+  content {
+    content = "${data.template_file.scheduler-kubeconfig.rendered}"
+  }
+}
+
+data "template_file" "controller-manager-kubeconfig" {
+  template = "${file("${path.module}/resources/controller-manager-kubeconfig")}"
+
+  vars {
+    master_address = "localhost:443"
+  }
+}
+
+data "ignition_file" "controller-manager-kubeconfig" {
+  mode       = 0644
+  filesystem = "root"
+  path       = "/etc/kubernetes/config/controller-manager.conf"
+
+  content {
+    content = "${data.template_file.controller-manager-kubeconfig.rendered}"
   }
 }
 
@@ -245,10 +404,16 @@ data "ignition_config" "master" {
         data.ignition_file.cfssl.id,
         data.ignition_file.cfssljson.id,
         data.ignition_file.cfssl-client-config.id,
-        data.ignition_file.master-cfssl-new-cert.id,
+        data.ignition_file.master-cfssl-new-node-cert.id,
+        data.ignition_file.master-cfssl-new-apiserver-cert.id,
+        data.ignition_file.master-cfssl-new-apiserver-kubelet-client-cert.id,
+        data.ignition_file.master-cfssl-new-scheduler-cert.id,
+        data.ignition_file.master-cfssl-new-controller-manager-cert.id,
         data.ignition_file.master-cfssl-keys-and-certs-get.id,
         data.ignition_file.master-prom-machine-role.id,
         data.ignition_file.master-kubeconfig.id,
+        data.ignition_file.scheduler-kubeconfig.id,
+        data.ignition_file.controller-manager-kubeconfig.id,
         data.ignition_file.kubelet-kubeconfig.id,
         data.ignition_file.kube-apiserver.id,
         data.ignition_file.kube-scheduler.id,

--- a/master.tf
+++ b/master.tf
@@ -21,7 +21,7 @@ data "template_file" "master-node-cfssl-new-cert" {
     org       = "system:master-nodes"
     get_ip    = "${var.get_ip_command[var.cloud_provider]}"
 
-    extra_names = "localhost"
+    extra_names = ""
   }
 }
 
@@ -58,6 +58,7 @@ data "template_file" "master-apiserver-cfssl-new-cert" {
       "elb.master.${var.dns_domain}",
       "*.master.${var.dns_domain}",
       "localhost",
+      "127.0.0.1",
     ))}"
   }
 }
@@ -85,7 +86,7 @@ data "template_file" "master-apiserver-kubelet-client-cfssl-new-cert" {
     cn          = "system:node:$(${var.node_name_command[var.cloud_provider]})"
     org         = "system:masters"
     get_ip      = "${var.get_ip_command[var.cloud_provider]}"
-    extra_names = "localhost"
+    extra_names = ""
   }
 }
 
@@ -112,7 +113,7 @@ data "template_file" "master-scheduler-cfssl-new-cert" {
     cn          = "system:kube-scheduler"
     org         = ""
     get_ip      = "${var.get_ip_command[var.cloud_provider]}"
-    extra_names = "localhost"
+    extra_names = ""
   }
 }
 
@@ -139,7 +140,7 @@ data "template_file" "master-controller-manager-cfssl-new-cert" {
     cn          = "system:kube-controller-manager"
     org         = ""
     get_ip      = "${var.get_ip_command[var.cloud_provider]}"
-    extra_names = "localhost"
+    extra_names = ""
   }
 }
 

--- a/resources/cfssl-new-cert.sh
+++ b/resources/cfssl-new-cert.sh
@@ -11,7 +11,7 @@ _hostname="$(hostname)"
 /opt/bin/cfssl gencert \
   -config=/etc/cfssl/config.json \
   -profile=${profile} \
-  -hostname="$${_ip},$${_hostname}${extra_names != "" ? ",${extra_names}" : "" }" - << EOF | /opt/bin/cfssljson -bare node
+  -hostname="$${_ip},$${_hostname}${extra_names != "" ? ",${extra_names}" : "" }" - << EOF | /opt/bin/cfssljson -bare ${cert_name}
 {"CN":"${cn}",${org != "" ? "\"names\":[{\"O\":\"${org}\"}]," : ""}"key":{"algo":"ecdsa","size":384}}
 EOF
 

--- a/resources/controller-manager-kubeconfig
+++ b/resources/controller-manager-kubeconfig
@@ -6,13 +6,13 @@ clusters:
     certificate-authority: /etc/kubernetes/ssl/ca.pem
     server: https://${master_address}
 users:
-- name: master-component
+- name: controller-manager
   user:
-    client-certificate: /etc/kubernetes/ssl/node.pem
-    client-key: /etc/kubernetes/ssl/node-key.pem
+    client-certificate: /etc/kubernetes/ssl/controller-manager.pem
+    client-key: /etc/kubernetes/ssl/controller-manager-key.pem
 contexts:
 - context:
     cluster: local
-    user: master-component
+    user: controller-manager
   name: kubelet-cluster.local
 current-context: kubelet-cluster.local

--- a/resources/kube-apiserver.yaml
+++ b/resources/kube-apiserver.yaml
@@ -14,15 +14,15 @@ spec:
     - kube-apiserver
     - --etcd-servers=${etcd_endpoints}
     - --etcd-cafile=/etc/kubernetes/ssl/ca.pem
-    - --etcd-certfile=/etc/kubernetes/ssl/node.pem
-    - --etcd-keyfile=/etc/kubernetes/ssl/node-key.pem
+    - --etcd-certfile=/etc/kubernetes/ssl/apiserver.pem
+    - --etcd-keyfile=/etc/kubernetes/ssl/apiserver-key.pem
     - --allow-privileged=true
     - --service-cluster-ip-range=${service_network}
     - --secure-port=443
     - --enable-admission-plugins=${admission_plugins}
     ${feature_gates == "" ? "" : "- --feature-gates=${feature_gates}"}
-    - --tls-cert-file=/etc/kubernetes/ssl/node.pem
-    - --tls-private-key-file=/etc/kubernetes/ssl/node-key.pem
+    - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
+    - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
     - --client-ca-file=/etc/kubernetes/ssl/ca.pem
     - --service-account-key-file=/etc/kubernetes/ssl/signing-key.pem
     - --service-account-lookup=true
@@ -45,8 +45,8 @@ spec:
     - --requestheader-username-headers=X-Remote-User
     - --proxy-client-cert-file=/etc/kubernetes/ssl/proxy.pem
     - --proxy-client-key-file=/etc/kubernetes/ssl/proxy-key.pem
-    - --kubelet-client-certificate=/etc/kubernetes/ssl/node.pem
-    - --kubelet-client-key=/etc/kubernetes/ssl/node-key.pem
+    - --kubelet-client-certificate=/etc/kubernetes/ssl/apiserver-kubelet-client.pem
+    - --kubelet-client-key=/etc/kubernetes/ssl/apiserver-kubelet-client-key.pem
     - --v=0
     livenessProbe:
       httpGet:

--- a/resources/kube-controller-manager.yaml
+++ b/resources/kube-controller-manager.yaml
@@ -11,7 +11,7 @@ spec:
     image: ${hyperkube_image_url}:${hyperkube_image_tag}
     command:
     - kube-controller-manager
-    - --master=http://127.0.0.1:8080
+    - --kubeconfig=/etc/kubernetes/config/controller-manager.conf
     - --leader-elect=true
     - --use-service-account-credentials
     - --service-account-private-key-file=/etc/kubernetes/ssl/signing-key.pem
@@ -38,8 +38,8 @@ spec:
     - mountPath: /etc/ssl/certs
       name: ssl-certs-host
       readOnly: true
-    - mountPath: /etc/kubernetes/config/cloud_provider
-      name: cloud-config
+    - mountPath: /etc/kubernetes/config
+      name: config
       readOnly: true
   hostNetwork: true
   volumes:
@@ -50,5 +50,5 @@ spec:
       path: /usr/share/ca-certificates
     name: ssl-certs-host
   - hostPath:
-      path: /etc/kubernetes/config/cloud_provider
-    name: cloud-config
+      path: /etc/kubernetes/config
+    name: config

--- a/resources/kube-scheduler-config.yaml
+++ b/resources/kube-scheduler-config.yaml
@@ -1,6 +1,6 @@
 kind: KubeSchedulerConfiguration
 apiVersion: kubescheduler.config.k8s.io/v1alpha1
 clientConnection:
-  kubeconfig: /etc/kubernetes/config/master-kubeconfig
+  kubeconfig: /etc/kubernetes/config/scheduler.conf
 leaderElection:
   leaderElect: true

--- a/resources/kube-scheduler.yaml
+++ b/resources/kube-scheduler.yaml
@@ -26,7 +26,13 @@ spec:
     - mountPath: /etc/kubernetes/config
       name: kubernetes-configurations
       readOnly: true
+    - mountPath: /etc/kubernetes/ssl
+      name: kubernetes-ssl
+      readOnly: true
   volumes:
   - hostPath:
       path: /etc/kubernetes/config
     name: kubernetes-configurations
+  - hostPath:
+      path: /etc/kubernetes/ssl
+    name: kubernetes-ssl

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -15,7 +15,11 @@ ExecStartPre=/usr/bin/mkdir -p /var/lib/calico
 #  https://github.com/kubernetes/kubernetes/issues/41916#issuecomment-312428731
 ExecStartPre=/sbin/sysctl -w net.ipv4.tcp_retries2=8
 ExecStartPre=/opt/bin/cfssl-keys-and-certs-get
-ExecStartPre=/opt/bin/cfssl-new-cert
+ExecStartPre=/opt/bin/cfssl-new-node-cert
+ExecStartPre=/opt/bin/cfssl-new-apiserver-cert
+ExecStartPre=/opt/bin/cfssl-new-apiserver-kubelet-client-cert
+ExecStartPre=/opt/bin/cfssl-new-scheduler-cert
+ExecStartPre=/opt/bin/cfssl-new-controller-manager-cert
 ExecStartPre=-/bin/sh -c "docker restart $(docker ps --no-trunc | grep 'kube-controller-manager' | awk '{ print $1; }')"
 ExecStartPre=-/bin/sh -c "docker restart $(docker ps --no-trunc | grep 'kube-apiserver' | awk '{ print $1; }')"
 ExecStart=/usr/bin/docker \

--- a/resources/scheduler-kubeconfig
+++ b/resources/scheduler-kubeconfig
@@ -6,13 +6,13 @@ clusters:
     certificate-authority: /etc/kubernetes/ssl/ca.pem
     server: https://${master_address}
 users:
-- name: master-component
+- name: kube-scheduler
   user:
-    client-certificate: /etc/kubernetes/ssl/node.pem
-    client-key: /etc/kubernetes/ssl/node-key.pem
+    client-certificate: /etc/kubernetes/ssl/scheduler.pem
+    client-key: /etc/kubernetes/ssl/scheduler-key.pem
 contexts:
 - context:
     cluster: local
-    user: master-component
+    user: kube-scheduler
   name: kubelet-cluster.local
 current-context: kubelet-cluster.local

--- a/worker.tf
+++ b/worker.tf
@@ -3,10 +3,12 @@ data "ignition_systemd_unit" "locksmithd_worker" {
   mask = "${!var.enable_container_linux_locksmithd_worker}"
 }
 
+// All nodes should belong to system:nodes group
 data "template_file" "worker-cfssl-new-cert" {
   template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
 
   vars {
+    cert_name   = "node"
     user        = "root"
     group       = "root"
     profile     = "client"


### PR DESCRIPTION
Inspired by https://kubernetes.io/docs/reference/setup-tools/kubeadm/implementation-details/

Add cert for master kubelet with CN system:master-nodes
Add cert for kube-apiserver
Add cert for kube-api to kubelet communication with CN system:masters to pass all auth
Add kube scheduler cert with CN system:kube-scheduler
Make scheduler use its own kubeconfig
Add certs for controller-manager with CN system:kube-controller-manager
Point cluster api endpoint to localhost inside master kubeconfigs

https://github.com/utilitywarehouse/kubernetes-manifests/pull/9089