### PR TITLE
Etcdctl executable

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -61,7 +61,7 @@ data "ignition_file" "etcdctl-wrapper" {
   filesystem = "root"
   uid        = 500
   gid        = 500
-  path       = "/home/core/etcdctl-wrapper"
+  path       = "/opt/bin/etcdctl-wrapper"
 
   content {
     content = "${element(data.template_file.etcdctl-wrapper.*.rendered, count.index)}"

--- a/resources/etcdctl-wrapper
+++ b/resources/etcdctl-wrapper
@@ -1,6 +1,6 @@
 #!/bin/sh
 docker run --rm \
-    -it \
+    -i \
     -v /etc/etcd/ssl:/etc/etcd/ssl \
     -e ETCDCTL_API=3 \
     --entrypoint /usr/local/bin/etcdctl \


### PR DESCRIPTION
Small wins:

```
$ ssh 10.66.23.4 /opt/bin/etcdctl-wrapper member list
Warning: Permanently added '10.66.23.4' (ECDSA) to the list of known hosts.
15ea8a4fd09ba9d, started, member2, https://10.66.23.132:2380, https://10.66.23.132:2379
337eb52116fa1cdc, started, member1, https://10.66.23.68:2380, https://10.66.23.68:2379
aee4fa7a004f654c, started, member0, https://10.66.23.4:2380, https://10.66.23.4:2379
```

Couldn't rename `etcdctl-wrapper` -> `etcdctl` as that already exists in CoreOS. Also when running commands over ssh, $PATH doesn't get loaded so you need to use full path.