### PR TITLE
Revert "sys: update default kube version to v1.13.3"

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "hyperkube_image_url" {
 
 variable "hyperkube_image_tag" {
   description = "The version of the hyperkube image to use."
-  default     = "v1.13.3"
+  default     = "v1.12.3"
 }
 
 variable "cluster_dns" {


### PR DESCRIPTION
This reverts commit 50d667ad13a5dd958078efceea3112651c16347f.

Broken release: https://github.com/kubernetes/kubernetes/issues/72102