### PR TITLE
Add ro_rootfs metric in a tmpfs folder

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -1,9 +1,3 @@
-// common configuration items
-data "ignition_filesystem" "root" {
-  name = "root"
-  path = "/sysroot"
-}
-
 data "ignition_systemd_unit" "update-engine" {
   name = "update-engine.service"
   mask = "${!var.enable_container_linux_update-engine}"

--- a/resources/hector.service
+++ b/resources/hector.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Hector test
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/usr/bin/mkdir -p /etc/prom-hector
+ExecStart=mount -t tmpfs -o size=10M,nr_inodes=1k,mode=755 tmpfs /etc/prom-hector
+[Install]
+WantedBy=multi-user.target

--- a/resources/hector.service
+++ b/resources/hector.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Hector test
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStartPre=/usr/bin/mkdir -p /etc/prom-hector
-ExecStart=mount -t tmpfs -o size=10M,nr_inodes=1k,mode=755 tmpfs /etc/prom-hector
-[Install]
-WantedBy=multi-user.target

--- a/resources/prometheus-machine-role.service
+++ b/resources/prometheus-machine-role.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Add the machine_role static metric to prometheus
+After=prometheus-tmpfs-dir.service
+Requires=prometheus-tmpfs-dir.service
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c 'echo machine_role{role=\\\"${role}\\\"} 1 > /etc/prom-text-collectors/machine_role.prom'
+[Install]
+WantedBy=multi-user.target

--- a/resources/prometheus-ro-rootfs
+++ b/resources/prometheus-ro-rootfs
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+textfile_collector_dir=/etc/prom-text-collectors
+metric_name=ro_rootfs
+
+ro_rootfs=$(grep " \/ " /proc/mounts | grep "[[:space:]]ro[[:space:],]")
+if [ -z "${ro_rootfs}" ]; then
+  metric_value=0
+else
+  metric_value=1
+fi
+
+# Write out metrics to a temporary file.
+cat << EOF > "${textfile_collector_dir}/${metric_name}.prom.$$"
+${metric_name} ${metric_value}
+EOF
+
+# Rename the temporary file atomically.
+# This avoids the node exporter seeing half a file.
+mv "${textfile_collector_dir}/${metric_name}.prom.$$" \
+  "${textfile_collector_dir}/${metric_name}.prom"

--- a/resources/prometheus-ro-rootfs.service
+++ b/resources/prometheus-ro-rootfs.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Runs ro-rootfs
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bin/prometheus-ro-rootfs

--- a/resources/prometheus-ro-rootfs.timer
+++ b/resources/prometheus-ro-rootfs.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run prometheus-ro-rootfs service periodically
+After=prometheus-tmpfs-dir.service
+Requires=prometheus-tmpfs-dir.service
+
+[Timer]
+OnBootSec=60
+OnUnitInactiveSec=10
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target

--- a/resources/prometheus-ro-rootfs.timer
+++ b/resources/prometheus-ro-rootfs.timer
@@ -5,8 +5,8 @@ Requires=prometheus-tmpfs-dir.service
 
 [Timer]
 OnBootSec=60
-OnUnitInactiveSec=10
-AccuracySec=1s
+OnUnitInactiveSec=30
+AccuracySec=5s
 
 [Install]
 WantedBy=timers.target

--- a/resources/prometheus-tmpfs-dir.service
+++ b/resources/prometheus-tmpfs-dir.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Mount a tmpfs dir for prometheus textfile collector
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/usr/bin/mkdir -p /etc/prom-text-collectors
+ExecStart=mount -t tmpfs -o size=10M,nr_inodes=1k,mode=755 tmpfs /etc/prom-text-collectors

--- a/worker.tf
+++ b/worker.tf
@@ -83,16 +83,6 @@ data "ignition_file" "worker-kubeconfig" {
   }
 }
 
-data "ignition_file" "worker-prom-machine-role" {
-  mode       = 0644
-  filesystem = "root"
-  path       = "/etc/prom-text-collectors/machine_role.prom"
-
-  content {
-    content = "machine_role{role=\"worker\"} 1\n"
-  }
-}
-
 data "ignition_file" "worker-sysctl-vm" {
   mode       = 0644
   filesystem = "root"
@@ -103,6 +93,57 @@ data "ignition_file" "worker-sysctl-vm" {
   }
 }
 
+data "template_file" "prometheus-tmpfs-dir" {
+  template = "${file("${path.module}/resources/prometheus-tmpfs-dir.service")}"
+}
+
+data "ignition_systemd_unit" "prometheus-tmpfs-dir" {
+  name    = "prometheus-tmpfs-dir.service"
+  content = "${data.template_file.prometheus-tmpfs-dir.rendered}"
+}
+
+data "template_file" "prometheus-machine-role" {
+  template = "${file("${path.module}/resources/prometheus-machine-role.service")}"
+
+  vars {
+    role = "worker"
+  }
+}
+
+data "ignition_systemd_unit" "prometheus-machine-role" {
+  name    = "prometheus-machine-role.service"
+  content = "${data.template_file.prometheus-machine-role.rendered}"
+}
+
+data "template_file" "prometheus-ro-rootfs" {
+  template = "${file("${path.module}/resources/prometheus-ro-rootfs.service")}"
+}
+
+data "ignition_systemd_unit" "prometheus-ro-rootfs" {
+  name    = "prometheus-ro-rootfs.service"
+  content = "${data.template_file.prometheus-ro-rootfs.rendered}"
+}
+
+data "template_file" "prometheus-ro-rootfs-timer" {
+  template = "${file("${path.module}/resources/prometheus-ro-rootfs.timer")}"
+}
+
+data "ignition_systemd_unit" "prometheus-ro-rootfs-timer" {
+  name    = "prometheus-ro-rootfs.timer"
+  content = "${data.template_file.prometheus-ro-rootfs-timer.rendered}"
+}
+
+data "ignition_file" "prometheus-ro-rootfs" {
+  mode       = 0755
+  filesystem = "root"
+  path       = "/opt/bin/prometheus-ro-rootfs"
+
+  content {
+    content = "${file("${path.module}/resources/prometheus-ro-rootfs")}"
+  }
+}
+
+// data.ignition_file.worker-prom-machine-role.id,
 data "ignition_config" "worker" {
   files = ["${concat(
     list(
@@ -110,10 +151,10 @@ data "ignition_config" "worker" {
         data.ignition_file.cfssljson.id,
         data.ignition_file.cfssl-client-config.id,
         data.ignition_file.worker-cfssl-new-cert.id,
-        data.ignition_file.worker-prom-machine-role.id,
         data.ignition_file.worker-kubeconfig.id,
         data.ignition_file.worker-sysctl-vm.id,
         data.ignition_file.worker-kubelet-conf.id,
+        data.ignition_file.prometheus-ro-rootfs.id,
     ),
     var.worker_additional_files
   )}"]
@@ -124,6 +165,10 @@ data "ignition_config" "worker" {
         data.ignition_systemd_unit.locksmithd_worker.id,
         data.ignition_systemd_unit.docker-opts-dropin.id,
         data.ignition_systemd_unit.worker-kubelet.id,
+        data.ignition_systemd_unit.prometheus-tmpfs-dir.id,
+        data.ignition_systemd_unit.prometheus-machine-role.id,
+        data.ignition_systemd_unit.prometheus-ro-rootfs.id,
+        data.ignition_systemd_unit.prometheus-ro-rootfs-timer.id,
     ),
     module.kubelet-restarter.systemd_units,
     var.worker_additional_systemd_units


### PR DESCRIPTION
* Removing dead code in `common.tf`
* Only for workers: mount the textfile collector dir as tmpfs and setup a timer that checks the ro status of the rootfs and updates a metric accordingly