### PR TITLE
Change generic get ip command to avoid network iface data

### DIFF
--- a/_data.tf
+++ b/_data.tf
@@ -12,7 +12,7 @@ variable "get_ip_command" {
   type = "map"
 
   default = {
-    ""    = "/usr/bin/ifconfig enp2s0 | grep 'inet ' | cut -d: -f2 | awk '{print $2}'"
+    ""    = "ip route get 1.2.3.4 | head  -n 1 | awk '{print $7}'"
     "aws" = "curl -s http://169.254.169.254/latest/meta-data/local-ipv4"
     "gce" = "curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip -H Metadata-Flavor:Google"
   }


### PR DESCRIPTION
no op for aws and gcp clusters 