### PR TITLE
sys: remove $$ escape from resources/cfssl-keys-and-certs-get

### DIFF
--- a/resources/cfssl-keys-and-certs-get
+++ b/resources/cfssl-keys-and-certs-get
@@ -3,7 +3,7 @@
 set -o errexit
 
 key() {
-  local key=$$1
+  local key=$1
   /usr/bin/curl -Ls -o $${key} \
       -H 'Authorization: Basic ${auth}' \
       http://$(jq -r '.remotes.server | split(":")[0]' /etc/cfssl/config.json):8889/$${key}
@@ -18,7 +18,7 @@ key() {
 }
 
 cert () {
-  local cert=$$1
+  local cert=$1
   /usr/bin/curl -Ls -o $${cert} \
       -H 'Authorization: Basic ${auth}' \
       http://$(jq -r '.remotes.server | split(":")[0]' /etc/cfssl/config.json):8889/$${cert}


### PR DESCRIPTION
That escape sequence is no longer supported in >= v2.0.0 of the template provider and simply resolves to `$$`.

~~However, removing this escape will break compatibility with provider versions earlier than v2.0.0. So we need to be mindful of that when updating or sourcing from master.~~