### PR TITLE
Convert to v0.12 syntax

### DIFF
--- a/_data.tf
+++ b/_data.tf
@@ -1,5 +1,5 @@
 variable "node_name_command" {
-  type = "map"
+  type = map(string)
 
   default = {
     ""    = "hostname -f"
@@ -9,7 +9,7 @@ variable "node_name_command" {
 }
 
 variable "get_ip_command" {
-  type = "map"
+  type = map(string)
 
   default = {
     ""    = "ip route get 1.2.3.4 | head  -n 1 | awk '{print $7}'"
@@ -20,5 +20,5 @@ variable "get_ip_command" {
 
 // master address is the first in the service subnet
 locals {
-  kubernetes_master_svc = "${cidrhost(var.service_network, 1)}"
+  kubernetes_master_svc = cidrhost(var.service_network, 1)
 }

--- a/cfssl.tf
+++ b/cfssl.tf
@@ -13,35 +13,35 @@ resource "random_id" "cfssl-auth-key-apiserver" {
 
 data "ignition_systemd_unit" "locksmithd_cfssl" {
   name = "locksmithd.service"
-  mask = "${!var.enable_container_linux_locksmithd_cfssl}"
+  mask = false == var.enable_container_linux_locksmithd_cfssl
 }
 
 // used by clients
 data "template_file" "cfssl-client-config" {
-  template = "${file("${path.module}/resources/cfssl-client-config.json")}"
+  template = file("${path.module}/resources/cfssl-client-config.json")
 
-  vars {
-    cfssl_server_endpoint = "${var.cfssl_server_address}"
-    cfssl_auth_key        = "${random_id.cfssl-auth-key-client.hex}"
+  vars = {
+    cfssl_server_endpoint = var.cfssl_server_address
+    cfssl_auth_key        = random_id.cfssl-auth-key-client.hex
   }
 }
 
 data "ignition_file" "cfssl-client-config" {
-  mode       = 0600
+  mode       = 384
   filesystem = "root"
   path       = "/etc/cfssl/config.json"
 
   content {
-    content = "${data.template_file.cfssl-client-config.rendered}"
+    content = data.template_file.cfssl-client-config.rendered
   }
 }
 
 data "template_file" "cfssl-disk-mounter" {
-  template = "${file("${path.module}/resources/disk-mounter.service")}"
+  template = file("${path.module}/resources/disk-mounter.service")
 
-  vars {
+  vars = {
     script_path = "/opt/bin/format-and-mount"
-    volume_id   = "${var.cfssl_data_volumeid}"
+    volume_id   = var.cfssl_data_volumeid
     filesystem  = "ext4"
     user        = "root"
     group       = "root"
@@ -51,11 +51,11 @@ data "template_file" "cfssl-disk-mounter" {
 
 data "ignition_systemd_unit" "cfssl-disk-mounter" {
   name    = "disk-mounter.service"
-  content = "${data.template_file.cfssl-disk-mounter.rendered}"
+  content = data.template_file.cfssl-disk-mounter.rendered
 }
 
 data "ignition_file" "cfssl-ca-csr" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/cfssl/ca-csr.json"
 
@@ -67,72 +67,72 @@ EOS
 }
 
 data "ignition_file" "cfssl-init-ca" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-init-ca"
 
   content {
-    content = "${file("${path.module}/resources/cfssl-init-ca.sh")}"
+    content = file("${path.module}/resources/cfssl-init-ca.sh")
   }
 }
 
 data "ignition_file" "cfssl-init-proxy-pki" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-init-proxy-pki"
 
   content {
-    content = "${file("${path.module}/resources/cfssl-init-proxy-pki")}"
+    content = file("${path.module}/resources/cfssl-init-proxy-pki")
   }
 }
 
 data "ignition_file" "cfssl-proxy-ca-csr-json" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/cfssl/proxy-ca-csr.json"
 
   content {
-    content = "${file("${path.module}/resources/cfssl-proxy-ca-csr.json")}"
+    content = file("${path.module}/resources/cfssl-proxy-ca-csr.json")
   }
 }
 
 data "ignition_file" "cfssl-proxy-csr-json" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/cfssl/proxy-csr.json"
 
   content {
-    content = "${file("${path.module}/resources/cfssl-proxy-csr.json")}"
+    content = file("${path.module}/resources/cfssl-proxy-csr.json")
   }
 }
 
 data "template_file" "cfssl-server-config" {
-  template = "${file("${path.module}/resources/cfssl-server-config.json")}"
+  template = file("${path.module}/resources/cfssl-server-config.json")
 
-  vars {
-    expiry_hours     = "${var.cfssl_node_expiry_hours}"
-    cfssl_unused_key = "${random_id.cfssl-auth-key-unused.hex}"
-    cfssl_auth_key   = "${random_id.cfssl-auth-key-client.hex}"
+  vars = {
+    expiry_hours     = var.cfssl_node_expiry_hours
+    cfssl_unused_key = random_id.cfssl-auth-key-unused.hex
+    cfssl_auth_key   = random_id.cfssl-auth-key-client.hex
   }
 }
 
 data "ignition_file" "cfssl-server-config" {
-  mode       = 0600
+  mode       = 384
   filesystem = "root"
   path       = "/etc/cfssl/config.json"
 
   content {
-    content = "${data.template_file.cfssl-server-config.rendered}"
+    content = data.template_file.cfssl-server-config.rendered
   }
 }
 
 data "ignition_systemd_unit" "cfssl" {
   name    = "cfssl.service"
-  content = "${file("${path.module}/resources/cfssl.service")}"
+  content = file("${path.module}/resources/cfssl.service")
 }
 
 data "ignition_file" "cfssl-sk-csr" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/cfssl/sk-csr.json"
 
@@ -144,17 +144,17 @@ EOS
 }
 
 data "ignition_file" "cfssl-nginx-conf" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/cfssl/sk-nginx.conf"
 
   content {
-    content = "${file("${path.module}/resources/cfssl-nginx.conf")}"
+    content = file("${path.module}/resources/cfssl-nginx.conf")
   }
 }
 
 data "ignition_file" "cfssl-nginx-auth" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/cfssl/sk-nginx.htpasswd"
 
@@ -166,9 +166,9 @@ data "ignition_file" "cfssl-nginx-auth" {
 }
 
 data "template_file" "cfssl-nginx" {
-  template = "${file("${path.module}/resources/cfssl-nginx.service")}"
+  template = file("${path.module}/resources/cfssl-nginx.service")
 
-  vars {
+  vars = {
     nginx_image_url = "nginx"
     nginx_image_tag = "1.15-alpine"
   }
@@ -177,7 +177,7 @@ data "template_file" "cfssl-nginx" {
 data "ignition_systemd_unit" "cfssl-nginx" {
   name = "cfssl-nginx.service"
 
-  content = "${data.template_file.cfssl-nginx.rendered}"
+  content = data.template_file.cfssl-nginx.rendered
 }
 
 module "cfssl-restarter" {
@@ -188,8 +188,8 @@ module "cfssl-restarter" {
 }
 
 data "ignition_config" "cfssl" {
-  files = ["${concat(
-    list(
+  files = concat(
+      [
         data.ignition_file.cfssl.id,
         data.ignition_file.cfssljson.id,
         data.ignition_file.cfssl-server-config.id,
@@ -202,12 +202,12 @@ data "ignition_config" "cfssl" {
         data.ignition_file.cfssl-nginx-conf.id,
         data.ignition_file.cfssl-nginx-auth.id,
         data.ignition_file.format-and-mount.id,
-    ),
-    var.cfssl_additional_files,
-  )}"]
+      ],
+      var.cfssl_additional_files
+    )
 
-  systemd = ["${concat(
-    list(
+  systemd = concat(
+      [
         data.ignition_systemd_unit.update-engine.id,
         data.ignition_systemd_unit.locksmithd_cfssl.id,
         data.ignition_systemd_unit.docker-opts-dropin.id,
@@ -215,8 +215,8 @@ data "ignition_config" "cfssl" {
         data.ignition_systemd_unit.cfssl.id,
         data.ignition_systemd_unit.cfssl-nginx.id,
         data.ignition_systemd_unit.cfssl-disk-mounter.id,
-    ),
-    module.cfssl-restarter.systemd_units,
-    var.cfssl_additional_systemd_units,
-  )}"]
+      ],
+      module.cfssl-restarter.systemd_units,
+      var.cfssl_additional_systemd_units
+    )
 }

--- a/common.tf
+++ b/common.tf
@@ -1,12 +1,12 @@
 data "ignition_systemd_unit" "update-engine" {
   name = "update-engine.service"
-  mask = "${!var.enable_container_linux_update-engine}"
+  mask = false == var.enable_container_linux_update-engine
 }
 
 data "ignition_file" "cfssl" {
   filesystem = "root"
   path       = "/opt/bin/cfssl"
-  mode       = 0755
+  mode       = 493
 
   source {
     source       = "https://pkg.cfssl.org/R1.2/cfssl_linux-amd64"
@@ -17,7 +17,7 @@ data "ignition_file" "cfssl" {
 data "ignition_file" "cfssljson" {
   filesystem = "root"
   path       = "/opt/bin/cfssljson"
-  mode       = 0755
+  mode       = 493
 
   source {
     source       = "https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64"
@@ -29,7 +29,7 @@ module "kubelet-restarter" {
   source = "./systemd_service_restarter"
 
   service_name = "kubelet"
-  on_calendar  = "${var.cfssl_node_renew_timer}"
+  on_calendar  = var.cfssl_node_renew_timer
 }
 
 data "ignition_systemd_unit" "docker-opts-dropin" {
@@ -37,31 +37,31 @@ data "ignition_systemd_unit" "docker-opts-dropin" {
 
   dropin {
     name    = "10-custom-options.conf"
-    content = "${file("${path.module}/resources/docker-dropin.conf")}"
+    content = file("${path.module}/resources/docker-dropin.conf")
   }
 }
 
 data "template_file" "node-exporter" {
-  template = "${file("${path.module}/resources/node-exporter.service")}"
+  template = file("${path.module}/resources/node-exporter.service")
 
-  vars {
-    node_exporter_image_url = "${var.node_exporter_image_url}"
-    node_exporter_image_tag = "${var.node_exporter_image_tag}"
+  vars = {
+    node_exporter_image_url = var.node_exporter_image_url
+    node_exporter_image_tag = var.node_exporter_image_tag
   }
 }
 
 data "ignition_systemd_unit" "node-exporter" {
   name = "node-exporter.service"
 
-  content = "${data.template_file.node-exporter.rendered}"
+  content = data.template_file.node-exporter.rendered
 }
 
 data "ignition_file" "format-and-mount" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/format-and-mount"
 
   content {
-    content = "${file("${path.module}/resources/format-and-mount")}"
+    content = file("${path.module}/resources/format-and-mount")
   }
 }

--- a/etcd.tf
+++ b/etcd.tf
@@ -1,13 +1,13 @@
 data "ignition_systemd_unit" "locksmithd_etcd" {
   name = "locksmithd.service"
-  mask = "${!var.enable_container_linux_locksmithd_etcd}"
+  mask = false == var.enable_container_linux_locksmithd_etcd
 }
 
 data "template_file" "etcd-cfssl-new-cert" {
-  count    = "${length(var.etcd_addresses)}"
-  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+  count    = length(var.etcd_addresses)
+  template = file("${path.module}/resources/cfssl-new-cert.sh")
 
-  vars {
+  vars = {
     cert_name = "node"
     user      = "etcd"
     group     = "etcd"
@@ -15,32 +15,31 @@ data "template_file" "etcd-cfssl-new-cert" {
     path      = "/etc/etcd/ssl"
     cn        = "${count.index}.etcd.${var.dns_domain}"
     org       = ""
-    get_ip    = "${var.get_ip_command[var.cloud_provider]}"
-
+    get_ip    = var.get_ip_command[var.cloud_provider]
     # workaround for https://github.com/kubernetes/kubernetes/issues/72102
     # include first member's ip in SAN for all nodes
     # this replicates kubeadm behaviour to include first node's ip, as kubeadm
     # generates all certificates on the first node
-    extra_names = "${join(",", list(
-      "etcd.${var.dns_domain}",
-      "${var.etcd_addresses[0]}",
-    ))}"
+    extra_names = join(",", ["etcd.${var.dns_domain}", var.etcd_addresses[0]])
   }
 }
 
 data "ignition_file" "etcd-cfssl-new-cert" {
-  count      = "${length(var.etcd_addresses)}"
-  mode       = 0755
+  count      = length(var.etcd_addresses)
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-new-cert"
 
   content {
-    content = "${element(data.template_file.etcd-cfssl-new-cert.*.rendered, count.index)}"
+    content = element(
+      data.template_file.etcd-cfssl-new-cert.*.rendered,
+      count.index,
+    )
   }
 }
 
 data "ignition_file" "etcd-prom-machine-role" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/prom-text-collectors/machine_role.prom"
 
@@ -50,36 +49,36 @@ data "ignition_file" "etcd-prom-machine-role" {
 }
 
 data "template_file" "etcdctl-wrapper" {
-  count    = "${length(var.etcd_addresses)}"
-  template = "${file("${path.module}/resources/etcdctl-wrapper")}"
+  count    = length(var.etcd_addresses)
+  template = file("${path.module}/resources/etcdctl-wrapper")
 
-  vars {
-    etcd_image_url = "${var.etcd_image_url}"
-    etcd_image_tag = "${var.etcd_image_tag}"
-    private_ipv4   = "${var.etcd_addresses[count.index]}"
+  vars = {
+    etcd_image_url = var.etcd_image_url
+    etcd_image_tag = var.etcd_image_tag
+    private_ipv4   = var.etcd_addresses[count.index]
   }
 }
 
 data "ignition_file" "etcdctl-wrapper" {
-  count      = "${length(var.etcd_addresses)}"
-  mode       = 0755
+  count      = length(var.etcd_addresses)
+  mode       = 493
   filesystem = "root"
   uid        = 500
   gid        = 500
   path       = "/opt/bin/etcdctl-wrapper"
 
   content {
-    content = "${element(data.template_file.etcdctl-wrapper.*.rendered, count.index)}"
+    content = element(data.template_file.etcdctl-wrapper.*.rendered, count.index)
   }
 }
 
 data "template_file" "etcd-disk-mounter" {
-  count    = "${length(var.etcd_addresses)}"
-  template = "${file("${path.module}/resources/disk-mounter.service")}"
+  count    = length(var.etcd_addresses)
+  template = file("${path.module}/resources/disk-mounter.service")
 
-  vars {
+  vars = {
     script_path = "/opt/bin/format-and-mount"
-    volume_id   = "${var.etcd_data_volumeids[count.index]}"
+    volume_id   = var.etcd_data_volumeids[count.index]
     filesystem  = "ext4"
     user        = "etcd"
     group       = "etcd"
@@ -88,74 +87,74 @@ data "template_file" "etcd-disk-mounter" {
 }
 
 data "ignition_systemd_unit" "etcd-disk-mounter" {
-  count   = "${length(var.etcd_addresses)}"
+  count   = length(var.etcd_addresses)
   name    = "disk-mounter.service"
-  content = "${data.template_file.etcd-disk-mounter.*.rendered[count.index]}"
+  content = data.template_file.etcd-disk-mounter[count.index].rendered
 }
 
 resource "null_resource" "etcd_member" {
-  count = "${length(var.etcd_addresses)}"
+  count = length(var.etcd_addresses)
 
-  triggers {
-    index = "${count.index}"
+  triggers = {
+    index = count.index
   }
 }
 
 data "template_file" "etcd-member-dropin" {
-  count    = "${length(var.etcd_addresses)}"
-  template = "${file("${path.module}/resources/etcd-member-dropin.conf")}"
+  count    = length(var.etcd_addresses)
+  template = file("${path.module}/resources/etcd-member-dropin.conf")
 
-  vars {
-    etcd_image_url       = "${var.etcd_image_url}"
-    etcd_image_tag       = "${var.etcd_image_tag}"
-    index                = "${count.index}"
-    etcd_initial_cluster = "${join(",", formatlist("member%s=https://%s:2380", null_resource.etcd_member.*.triggers.index, var.etcd_addresses))}"
-    private_ipv4         = "${var.etcd_addresses[count.index]}"
+  vars = {
+    etcd_image_url       = var.etcd_image_url
+    etcd_image_tag       = var.etcd_image_tag
+    index                = count.index
+    etcd_initial_cluster = join(",", formatlist("member%s=https://%s:2380", null_resource.etcd_member.*.triggers.index, var.etcd_addresses))
+    private_ipv4         = var.etcd_addresses[count.index]
   }
 }
 
 data "ignition_systemd_unit" "etcd-member-dropin" {
-  count = "${length(var.etcd_addresses)}"
+  count = length(var.etcd_addresses)
   name  = "etcd-member.service"
 
   dropin {
     name    = "10-custom-options.conf"
-    content = "${element(data.template_file.etcd-member-dropin.*.rendered, count.index)}"
+    content = element(data.template_file.etcd-member-dropin.*.rendered, count.index)
   }
 }
 
 module "etcd-cert-fetcher" {
   source = "./cert-fetcher"
 
-  on_calendar = "${var.cfssl_node_renew_timer}"
+  on_calendar = var.cfssl_node_renew_timer
 }
 
 data "ignition_config" "etcd" {
-  count = "${length(var.etcd_addresses)}"
+  count = length(var.etcd_addresses)
 
-  files = ["${concat(
-    list(
+  files = concat(
+      [
         data.ignition_file.cfssl.id,
         data.ignition_file.cfssljson.id,
         data.ignition_file.cfssl-client-config.id,
         element(data.ignition_file.etcd-cfssl-new-cert.*.id, count.index),
         data.ignition_file.etcd-prom-machine-role.id,
         element(data.ignition_file.etcdctl-wrapper.*.id, count.index),
-        data.ignition_file.format-and-mount.id,
-    ),
-    var.etcd_additional_files,
-  )}"]
+        data.ignition_file.format-and-mount.id
+      ],
+      var.etcd_additional_files
+    )
 
-  systemd = ["${concat(
-    list(
+  systemd = concat(
+      [
         data.ignition_systemd_unit.update-engine.id,
         data.ignition_systemd_unit.locksmithd_etcd.id,
         data.ignition_systemd_unit.docker-opts-dropin.id,
         data.ignition_systemd_unit.node-exporter.id,
         element(data.ignition_systemd_unit.etcd-member-dropin.*.id, count.index),
-        element(data.ignition_systemd_unit.etcd-disk-mounter.*.id, count.index),
-    ),
-    module.etcd-cert-fetcher.systemd_units,
-    var.etcd_additional_systemd_units,
-  )}"]
+        element(data.ignition_systemd_unit.etcd-disk-mounter.*.id, count.index)
+      ],
+      module.etcd-cert-fetcher.systemd_units,
+      var.etcd_additional_systemd_units
+    )
 }

--- a/master.tf
+++ b/master.tf
@@ -1,6 +1,6 @@
 data "ignition_systemd_unit" "locksmithd_master" {
   name = "locksmithd.service"
-  mask = "${!var.enable_container_linux_locksmithd_master}"
+  mask = false == var.enable_container_linux_locksmithd_master
 }
 
 // Node certificate for kubelet to use as part of system:master-nodes. We need
@@ -9,37 +9,36 @@ data "ignition_systemd_unit" "locksmithd_master" {
 // kubelets must use a credential that identifies them as being in the
 // system:nodes group, with a username of system:node:<nodeName>
 data "template_file" "master-node-cfssl-new-cert" {
-  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+  template = file("${path.module}/resources/cfssl-new-cert.sh")
 
-  vars {
-    cert_name = "node"
-    user      = "root"
-    group     = "root"
-    profile   = "client-server"
-    path      = "/etc/kubernetes/ssl"
-    cn        = "system:node:$(${var.node_name_command[var.cloud_provider]})"
-    org       = "system:master-nodes"
-    get_ip    = "${var.get_ip_command[var.cloud_provider]}"
-
+  vars = {
+    cert_name   = "node"
+    user        = "root"
+    group       = "root"
+    profile     = "client-server"
+    path        = "/etc/kubernetes/ssl"
+    cn          = "system:node:$(${var.node_name_command[var.cloud_provider]})"
+    org         = "system:master-nodes"
+    get_ip      = var.get_ip_command[var.cloud_provider]
     extra_names = ""
   }
 }
 
 data "ignition_file" "master-cfssl-new-node-cert" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-new-node-cert"
 
   content {
-    content = "${data.template_file.master-node-cfssl-new-cert.rendered}"
+    content = data.template_file.master-node-cfssl-new-cert.rendered
   }
 }
 
 // Serving certificate for the API server
 data "template_file" "master-apiserver-cfssl-new-cert" {
-  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+  template = file("${path.module}/resources/cfssl-new-cert.sh")
 
-  vars {
+  vars = {
     cert_name = "apiserver"
     user      = "root"
     group     = "root"
@@ -47,37 +46,39 @@ data "template_file" "master-apiserver-cfssl-new-cert" {
     path      = "/etc/kubernetes/ssl"
     cn        = "system:node:$(${var.node_name_command[var.cloud_provider]})"
     org       = ""
-    get_ip    = "${var.get_ip_command[var.cloud_provider]}"
-
-    extra_names = "${join(",", list(
-      "${local.kubernetes_master_svc}",
-      "kubernetes",
-      "kubernetes.default",
-      "kubernetes.default.svc",
-      "kubernetes.default.svc.cluster.local",
-      "elb.master.${var.dns_domain}",
-      "*.master.${var.dns_domain}",
-      "localhost",
-      "127.0.0.1",
-    ))}"
+    get_ip    = var.get_ip_command[var.cloud_provider]
+    extra_names = join(
+      ",",
+      [
+        local.kubernetes_master_svc,
+        "kubernetes",
+        "kubernetes.default",
+        "kubernetes.default.svc",
+        "kubernetes.default.svc.cluster.local",
+        "elb.master.${var.dns_domain}",
+        "*.master.${var.dns_domain}",
+        "localhost",
+        "127.0.0.1",
+      ],
+    )
   }
 }
 
 data "ignition_file" "master-cfssl-new-apiserver-cert" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-new-apiserver-cert"
 
   content {
-    content = "${data.template_file.master-apiserver-cfssl-new-cert.rendered}"
+    content = data.template_file.master-apiserver-cfssl-new-cert.rendered
   }
 }
 
 // Client certificate for the API server to connect to the kubelets securely
 data "template_file" "master-apiserver-kubelet-client-cfssl-new-cert" {
-  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+  template = file("${path.module}/resources/cfssl-new-cert.sh")
 
-  vars {
+  vars = {
     cert_name   = "apiserver-kubelet-client"
     user        = "root"
     group       = "root"
@@ -85,26 +86,26 @@ data "template_file" "master-apiserver-kubelet-client-cfssl-new-cert" {
     path        = "/etc/kubernetes/ssl"
     cn          = "system:node:$(${var.node_name_command[var.cloud_provider]})"
     org         = "system:masters"
-    get_ip      = "${var.get_ip_command[var.cloud_provider]}"
+    get_ip      = var.get_ip_command[var.cloud_provider]
     extra_names = ""
   }
 }
 
 data "ignition_file" "master-cfssl-new-apiserver-kubelet-client-cert" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-new-apiserver-kubelet-client-cert"
 
   content {
-    content = "${data.template_file.master-apiserver-kubelet-client-cfssl-new-cert.rendered}"
+    content = data.template_file.master-apiserver-kubelet-client-cfssl-new-cert.rendered
   }
 }
 
 // Client certificate for kube-scheduler
 data "template_file" "master-scheduler-cfssl-new-cert" {
-  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+  template = file("${path.module}/resources/cfssl-new-cert.sh")
 
-  vars {
+  vars = {
     cert_name   = "scheduler"
     user        = "root"
     group       = "root"
@@ -112,26 +113,26 @@ data "template_file" "master-scheduler-cfssl-new-cert" {
     path        = "/etc/kubernetes/ssl"
     cn          = "system:kube-scheduler"
     org         = ""
-    get_ip      = "${var.get_ip_command[var.cloud_provider]}"
+    get_ip      = var.get_ip_command[var.cloud_provider]
     extra_names = ""
   }
 }
 
 data "ignition_file" "master-cfssl-new-scheduler-cert" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-new-scheduler-cert"
 
   content {
-    content = "${data.template_file.master-scheduler-cfssl-new-cert.rendered}"
+    content = data.template_file.master-scheduler-cfssl-new-cert.rendered
   }
 }
 
 // Client certificate for kube-controller-manager
 data "template_file" "master-controller-manager-cfssl-new-cert" {
-  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+  template = file("${path.module}/resources/cfssl-new-cert.sh")
 
-  vars {
+  vars = {
     cert_name   = "controller-manager"
     user        = "root"
     group       = "root"
@@ -139,244 +140,242 @@ data "template_file" "master-controller-manager-cfssl-new-cert" {
     path        = "/etc/kubernetes/ssl"
     cn          = "system:kube-controller-manager"
     org         = ""
-    get_ip      = "${var.get_ip_command[var.cloud_provider]}"
+    get_ip      = var.get_ip_command[var.cloud_provider]
     extra_names = ""
   }
 }
 
 data "ignition_file" "master-cfssl-new-controller-manager-cert" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-new-controller-manager-cert"
 
   content {
-    content = "${data.template_file.master-controller-manager-cfssl-new-cert.rendered}"
+    content = data.template_file.master-controller-manager-cfssl-new-cert.rendered
   }
 }
 
 data "template_file" "master-cfssl-keys-and-certs-get" {
-  template = "${file("${path.module}/resources/cfssl-keys-and-certs-get")}"
+  template = file("${path.module}/resources/cfssl-keys-and-certs-get")
 
-  vars {
+  vars = {
     path = "/etc/kubernetes/ssl"
-    auth = "${base64encode("apiserver:${random_id.cfssl-auth-key-apiserver.hex}")}"
+    auth = base64encode("apiserver:${random_id.cfssl-auth-key-apiserver.hex}")
   }
 }
 
 data "ignition_file" "master-cfssl-keys-and-certs-get" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-keys-and-certs-get"
 
   content {
-    content = "${data.template_file.master-cfssl-keys-and-certs-get.rendered}"
+    content = data.template_file.master-cfssl-keys-and-certs-get.rendered
   }
 }
 
 data "template_file" "master-kubelet" {
-  template = "${file("${path.module}/resources/master-kubelet.service")}"
+  template = file("${path.module}/resources/master-kubelet.service")
 
-  vars {
-    kubelet_image_url = "${var.hyperkube_image_url}"
-    kubelet_image_tag = "${var.hyperkube_image_tag}"
-    cloud_provider    = "${var.cloud_provider}"
+  vars = {
+    kubelet_image_url = var.hyperkube_image_url
+    kubelet_image_tag = var.hyperkube_image_tag
+    cloud_provider    = var.cloud_provider
   }
 }
 
 data "ignition_systemd_unit" "master-kubelet" {
   name    = "kubelet.service"
-  content = "${data.template_file.master-kubelet.rendered}"
+  content = data.template_file.master-kubelet.rendered
 }
 
 data "template_file" "master-kubelet-conf" {
-  template = "${file("${path.module}/resources/master-kubelet-conf.yaml")}"
+  template = file("${path.module}/resources/master-kubelet-conf.yaml")
 
-  vars {
-    cluster_dns   = "${local.cluster_dns_yaml}"
-    feature_gates = "${local.feature_gates_yaml_fragment}"
+  vars = {
+    cluster_dns   = local.cluster_dns_yaml
+    feature_gates = local.feature_gates_yaml_fragment
   }
 }
 
 data "ignition_file" "master-kubelet-conf" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/config/master-kubelet-conf.yaml"
 
   content {
-    content = "${data.template_file.master-kubelet-conf.rendered}"
+    content = data.template_file.master-kubelet-conf.rendered
   }
 }
 
 data "template_file" "master-kubeconfig" {
-  template = "${file("${path.module}/resources/master-kubeconfig")}"
+  template = file("${path.module}/resources/master-kubeconfig")
 
-  vars {
+  vars = {
     master_address = "localhost:443"
   }
 }
 
 data "ignition_file" "kubelet-kubeconfig" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/var/lib/kubelet/kubeconfig"
 
   content {
-    content = "${data.template_file.master-kubeconfig.rendered}"
+    content = data.template_file.master-kubeconfig.rendered
   }
 }
 
 data "template_file" "scheduler-kubeconfig" {
-  template = "${file("${path.module}/resources/scheduler-kubeconfig")}"
+  template = file("${path.module}/resources/scheduler-kubeconfig")
 
-  vars {
+  vars = {
     master_address = "localhost:443"
   }
 }
 
 data "ignition_file" "scheduler-kubeconfig" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/config/scheduler.conf"
 
   content {
-    content = "${data.template_file.scheduler-kubeconfig.rendered}"
+    content = data.template_file.scheduler-kubeconfig.rendered
   }
 }
 
 data "template_file" "controller-manager-kubeconfig" {
-  template = "${file("${path.module}/resources/controller-manager-kubeconfig")}"
+  template = file("${path.module}/resources/controller-manager-kubeconfig")
 
-  vars {
+  vars = {
     master_address = "localhost:443"
   }
 }
 
 data "ignition_file" "controller-manager-kubeconfig" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/config/controller-manager.conf"
 
   content {
-    content = "${data.template_file.controller-manager-kubeconfig.rendered}"
+    content = data.template_file.controller-manager-kubeconfig.rendered
   }
 }
 
 data "template_file" "kube-apiserver" {
-  template = "${file("${path.module}/resources/kube-apiserver.yaml")}"
+  template = file("${path.module}/resources/kube-apiserver.yaml")
 
-  vars {
-    hyperkube_image_url   = "${var.hyperkube_image_url}"
-    hyperkube_image_tag   = "${var.hyperkube_image_tag}"
-    etcd_endpoints        = "${join(",", formatlist("https://%s:2379", var.etcd_addresses))}"
-    service_network       = "${var.service_network}"
-    master_address        = "${var.master_address}"
-    master_instance_count = "${var.master_instance_count}"
-    cloud_provider        = "${var.cloud_provider}"
-    oidc_issuer_url       = "${var.oidc_issuer_url}"
-    oidc_client_id        = "${var.oidc_client_id}"
-    feature_gates         = "${local.feature_gates_csv}"
-    admission_plugins     = "${var.admission_plugins}"
-
-    /*
+  vars = {
+    hyperkube_image_url   = var.hyperkube_image_url
+    hyperkube_image_tag   = var.hyperkube_image_tag
+    etcd_endpoints        = join(",", formatlist("https://%s:2379", var.etcd_addresses))
+    service_network       = var.service_network
+    master_address        = var.master_address
+    master_instance_count = var.master_instance_count
+    cloud_provider        = var.cloud_provider
+    oidc_issuer_url       = var.oidc_issuer_url
+    oidc_client_id        = var.oidc_client_id
+    feature_gates         = local.feature_gates_csv
+    admission_plugins     = var.admission_plugins
+    runtime_config        = join(",", [])
+  }
+  /*
      * for the list of APIs & resources enabled by default, please see near the
      * bottom of the file:
      *   https://github.com/kubernetes/kubernetes/blob/<ref>/pkg/master/master.go
      *
      */
-
-    runtime_config = "${join(",", list())}"
-  }
 }
 
 data "ignition_file" "kube-apiserver" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/manifests/kube-apiserver.yaml"
 
   content {
-    content = "${data.template_file.kube-apiserver.rendered}"
+    content = data.template_file.kube-apiserver.rendered
   }
 }
 
 data "template_file" "audit-policy" {
-  template = "${file("${path.module}/resources/audit-policy.yaml")}"
+  template = file("${path.module}/resources/audit-policy.yaml")
 }
 
 data "ignition_file" "audit-policy" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/config/audit-policy.yaml"
 
   content {
-    content = "${data.template_file.audit-policy.rendered}"
+    content = data.template_file.audit-policy.rendered
   }
 }
 
 data "template_file" "kube-controller-manager" {
-  template = "${file("${path.module}/resources/kube-controller-manager.yaml")}"
+  template = file("${path.module}/resources/kube-controller-manager.yaml")
 
-  vars {
-    hyperkube_image_url = "${var.hyperkube_image_url}"
-    hyperkube_image_tag = "${var.hyperkube_image_tag}"
-    cloud_provider      = "${var.cloud_provider}"
-    cloud_config        = "${var.kube_controller_cloud_config}"
-    pod_network         = "${var.pod_network}"
-    feature_gates       = "${local.feature_gates_csv}"
+  vars = {
+    hyperkube_image_url = var.hyperkube_image_url
+    hyperkube_image_tag = var.hyperkube_image_tag
+    cloud_provider      = var.cloud_provider
+    cloud_config        = var.kube_controller_cloud_config
+    pod_network         = var.pod_network
+    feature_gates       = local.feature_gates_csv
   }
 }
 
 data "ignition_file" "kube-controller-manager" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/manifests/kube-controller-manager.yaml"
 
   content {
-    content = "${data.template_file.kube-controller-manager.rendered}"
+    content = data.template_file.kube-controller-manager.rendered
   }
 }
 
 data "ignition_file" "kube-controller-conf" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/config/cloud_provider/cloud.conf"
 
   content {
-    content = "${var.kube_controller_cloud_config}"
+    content = var.kube_controller_cloud_config
   }
 }
 
 data "template_file" "kube-scheduler" {
-  template = "${file("${path.module}/resources/kube-scheduler.yaml")}"
+  template = file("${path.module}/resources/kube-scheduler.yaml")
 
-  vars {
-    hyperkube_image_url = "${var.hyperkube_image_url}"
-    hyperkube_image_tag = "${var.hyperkube_image_tag}"
-    feature_gates       = "${local.feature_gates_csv}"
+  vars = {
+    hyperkube_image_url = var.hyperkube_image_url
+    hyperkube_image_tag = var.hyperkube_image_tag
+    feature_gates       = local.feature_gates_csv
   }
 }
 
 data "ignition_file" "kube-scheduler" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/manifests/kube-scheduler.yaml"
 
   content {
-    content = "${data.template_file.kube-scheduler.rendered}"
+    content = data.template_file.kube-scheduler.rendered
   }
 }
 
 data "ignition_file" "kube-scheduler-config" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/config/kube-scheduler-config.yaml"
 
   content {
-    content = "${file("${path.module}/resources/kube-scheduler-config.yaml")}"
+    content = file("${path.module}/resources/kube-scheduler-config.yaml")
   }
 }
 
 data "ignition_file" "master-prom-machine-role" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/prom-text-collectors/machine_role.prom"
 
@@ -386,12 +385,12 @@ data "ignition_file" "master-prom-machine-role" {
 }
 
 locals {
-  kube_controller_additional_config = "${var.kube_controller_cloud_config == "" ? "" : data.ignition_file.kube-controller-conf.id}"
+  kube_controller_additional_config = var.kube_controller_cloud_config == "" ? "" : data.ignition_file.kube-controller-conf.id
 }
 
 data "ignition_config" "master" {
-  files = ["${concat(
-    list(
+  files = concat(
+      [
         data.ignition_file.audit-policy.id,
         data.ignition_file.cfssl.id,
         data.ignition_file.cfssljson.id,
@@ -411,19 +410,19 @@ data "ignition_config" "master" {
         data.ignition_file.kube-scheduler-config.id,
         data.ignition_file.kube-controller-manager.id,
         data.ignition_file.master-kubelet-conf.id,
-    ),
-    var.master_additional_files,
-    list(local.kube_controller_additional_config,)
-  )}"]
+      ],
+      var.master_additional_files,
+      [local.kube_controller_additional_config]
+    )
 
-  systemd = ["${concat(
-    list(
+  systemd = concat(
+      [
         data.ignition_systemd_unit.update-engine.id,
         data.ignition_systemd_unit.locksmithd_master.id,
         data.ignition_systemd_unit.docker-opts-dropin.id,
         data.ignition_systemd_unit.master-kubelet.id,
-    ),
-    module.kubelet-restarter.systemd_units,
-    var.master_additional_systemd_units,
-  )}"]
+      ],
+      module.kubelet-restarter.systemd_units,
+      var.master_additional_systemd_units
+    )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,48 +1,48 @@
 output "cfssl" {
-  value = "${data.ignition_config.cfssl.rendered}"
+  value = data.ignition_config.cfssl.rendered
 }
 
 output "master" {
-  value = "${data.ignition_config.master.rendered}"
+  value = data.ignition_config.master.rendered
 }
 
 output "worker" {
-  value = "${data.ignition_config.worker.rendered}"
+  value = data.ignition_config.worker.rendered
 }
 
 output "etcd" {
-  value = ["${data.ignition_config.etcd.*.rendered}"]
+  value = data.ignition_config.etcd.*.rendered
 }
 
 // Also output ignition config systemd and files for stuff like on-prem that need to manipulate those
 output "cfssl_ignition_systemd" {
-  value = "${data.ignition_config.cfssl.systemd}"
+  value = data.ignition_config.cfssl.systemd
 }
 
 output "cfssl_ignition_files" {
-  value = "${data.ignition_config.cfssl.files}"
+  value = data.ignition_config.cfssl.files
 }
 
 output "master_ignition_systemd" {
-  value = "${data.ignition_config.master.systemd}"
+  value = data.ignition_config.master.systemd
 }
 
 output "master_ignition_files" {
-  value = "${data.ignition_config.master.files}"
+  value = data.ignition_config.master.files
 }
 
 output "worker_ignition_systemd" {
-  value = "${data.ignition_config.worker.systemd}"
+  value = data.ignition_config.worker.systemd
 }
 
 output "worker_ignition_files" {
-  value = "${data.ignition_config.worker.files}"
+  value = data.ignition_config.worker.files
 }
 
 output "etcd_ignition_systemd" {
-  value = ["${data.ignition_config.etcd.*.systemd}"]
+  value = [data.ignition_config.etcd.*.systemd]
 }
 
 output "etcd_ignition_files" {
-  value = ["${data.ignition_config.etcd.*.files}"]
+  value = [data.ignition_config.etcd.*.files]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "hyperkube_image_tag" {
 
 variable "cluster_dns" {
   description = "List of DNS server IP addresses. Used by kubelet."
-  type        = "list"
+  type        = list(string)
 }
 
 variable "master_address" {
@@ -83,7 +83,7 @@ variable "master_instance_count" {
 
 variable "etcd_addresses" {
   description = "A list of IP addresses for the etcd nodes. Used by the etcd services and the API server."
-  type        = "list"
+  type        = list(string)
 }
 
 variable "oidc_issuer_url" {
@@ -107,49 +107,49 @@ variable "pod_network" {
 variable "cfssl_additional_systemd_units" {
   description = "Additional systemd units to include in the igntion config data for the cfssl node."
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "cfssl_additional_files" {
   description = "Additional files to include in the igntion config data for the cfssl node."
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "etcd_additional_systemd_units" {
   description = "Additional systemd units to include in the igntion config data for etcd nodes."
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "etcd_additional_files" {
   description = "Additional files to include in the igntion config data for etcd nodes."
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "master_additional_systemd_units" {
   description = "Additional systemd units to include in the igntion config data for master nodes."
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "master_additional_files" {
   description = "Additional files to include in the igntion config data for master nodes."
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "worker_additional_systemd_units" {
   description = "Additional systemd units to include in the igntion config data for worker nodes."
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "worker_additional_files" {
   description = "Additional files to include in the igntion config data for worker nodes."
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "cfssl_ca_cn" {
@@ -175,15 +175,16 @@ variable "cfssl_server_address" {
   description = "The IP address of the cfssl server."
 }
 
-variable "cfssl_data_volumeid" {}
+variable "cfssl_data_volumeid" {
+}
 
 variable "etcd_data_volumeids" {
-  type = "list"
+  type = list(string)
 }
 
 variable "feature_gates" {
   description = "https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/"
-  type        = "map"
+  type        = map(string)
 
   # yaml fragment for config file use, example default feature gates:
   # ```
@@ -203,7 +204,7 @@ variable "admission_plugins" {
 locals {
   # Comma separated list for cli flas use, example output:
   # `ExpandPersistentVolumes=true,PodShareProcessNamespace=true,AdvancedAuditing=false`
-  feature_gates_csv = "${join(",", formatlist("%s=%s", keys(var.feature_gates), values(var.feature_gates)))}"
+  feature_gates_csv = join(",", formatlist("%s=%s", keys(var.feature_gates), values(var.feature_gates)))
 
   # yaml fragment for config file use, example output:
   # ```
@@ -214,7 +215,7 @@ locals {
   #
   # note the two white space chars at the start of the line, this corresponds to the
   # formatting in worker-kubelet-conf.yaml and master-kubelet-conf.yaml
-  feature_gates_yaml_fragment = "${join("\n  ", formatlist("%s: %s", keys(var.feature_gates), values(var.feature_gates)))}"
+  feature_gates_yaml_fragment = join("\n  ", formatlist("%s: %s", keys(var.feature_gates), values(var.feature_gates)))
 
   # cluster_dns list formatted for KubeletConfiguration yaml
   #
@@ -225,5 +226,5 @@ locals {
   #    - "169.254.20.10"
   #    - "10.3.0.10"
   #
-  cluster_dns_yaml = "${join("", formatlist("\n  - \"%s\"", var.cluster_dns))}"
+  cluster_dns_yaml = join("", formatlist("\n  - \"%s\"", var.cluster_dns))
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/worker.tf
+++ b/worker.tf
@@ -1,13 +1,13 @@
 data "ignition_systemd_unit" "locksmithd_worker" {
   name = "locksmithd.service"
-  mask = "${!var.enable_container_linux_locksmithd_worker}"
+  mask = false == var.enable_container_linux_locksmithd_worker
 }
 
 // All nodes should belong to system:nodes group
 data "template_file" "worker-cfssl-new-cert" {
-  template = "${file("${path.module}/resources/cfssl-new-cert.sh")}"
+  template = file("${path.module}/resources/cfssl-new-cert.sh")
 
-  vars {
+  vars = {
     cert_name   = "node"
     user        = "root"
     group       = "root"
@@ -15,76 +15,76 @@ data "template_file" "worker-cfssl-new-cert" {
     path        = "/etc/kubernetes/ssl"
     cn          = "system:node:$(${var.node_name_command[var.cloud_provider]})"
     org         = "system:nodes"
-    get_ip      = "${var.get_ip_command[var.cloud_provider]}"
+    get_ip      = var.get_ip_command[var.cloud_provider]
     extra_names = ""
   }
 }
 
 data "ignition_file" "worker-cfssl-new-cert" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/cfssl-new-cert"
 
   content {
-    content = "${data.template_file.worker-cfssl-new-cert.rendered}"
+    content = data.template_file.worker-cfssl-new-cert.rendered
   }
 }
 
 data "template_file" "worker-kubelet" {
-  template = "${file("${path.module}/resources/worker-kubelet.service")}"
+  template = file("${path.module}/resources/worker-kubelet.service")
 
-  vars {
-    kubelet_image_url = "${var.hyperkube_image_url}"
-    kubelet_image_tag = "${var.hyperkube_image_tag}"
-    cloud_provider    = "${var.cloud_provider}"
+  vars = {
+    kubelet_image_url = var.hyperkube_image_url
+    kubelet_image_tag = var.hyperkube_image_tag
+    cloud_provider    = var.cloud_provider
     role              = "worker"
   }
 }
 
 data "ignition_systemd_unit" "worker-kubelet" {
   name    = "kubelet.service"
-  content = "${data.template_file.worker-kubelet.rendered}"
+  content = data.template_file.worker-kubelet.rendered
 }
 
 data "template_file" "worker-kubelet-conf" {
-  template = "${file("${path.module}/resources/worker-kubelet-conf.yaml")}"
+  template = file("${path.module}/resources/worker-kubelet-conf.yaml")
 
-  vars {
-    cluster_dns   = "${local.cluster_dns_yaml}"
-    feature_gates = "${local.feature_gates_yaml_fragment}"
+  vars = {
+    cluster_dns   = local.cluster_dns_yaml
+    feature_gates = local.feature_gates_yaml_fragment
   }
 }
 
 data "ignition_file" "worker-kubelet-conf" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/kubernetes/config/worker-kubelet-conf.yaml"
 
   content {
-    content = "${data.template_file.worker-kubelet-conf.rendered}"
+    content = data.template_file.worker-kubelet-conf.rendered
   }
 }
 
 data "template_file" "worker-kubeconfig" {
-  template = "${file("${path.module}/resources/worker-kubeconfig")}"
+  template = file("${path.module}/resources/worker-kubeconfig")
 
-  vars {
-    master_address = "${var.master_address}"
+  vars = {
+    master_address = var.master_address
   }
 }
 
 data "ignition_file" "worker-kubeconfig" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/var/lib/kubelet/kubeconfig"
 
   content {
-    content = "${data.template_file.worker-kubeconfig.rendered}"
+    content = data.template_file.worker-kubeconfig.rendered
   }
 }
 
 data "ignition_file" "worker-sysctl-vm" {
-  mode       = 0644
+  mode       = 420
   filesystem = "root"
   path       = "/etc/sysctl.d/vm.conf"
 
@@ -94,59 +94,59 @@ data "ignition_file" "worker-sysctl-vm" {
 }
 
 data "template_file" "prometheus-tmpfs-dir" {
-  template = "${file("${path.module}/resources/prometheus-tmpfs-dir.service")}"
+  template = file("${path.module}/resources/prometheus-tmpfs-dir.service")
 }
 
 data "ignition_systemd_unit" "prometheus-tmpfs-dir" {
   name    = "prometheus-tmpfs-dir.service"
-  content = "${data.template_file.prometheus-tmpfs-dir.rendered}"
+  content = data.template_file.prometheus-tmpfs-dir.rendered
 }
 
 data "template_file" "prometheus-machine-role" {
-  template = "${file("${path.module}/resources/prometheus-machine-role.service")}"
+  template = file("${path.module}/resources/prometheus-machine-role.service")
 
-  vars {
+  vars = {
     role = "worker"
   }
 }
 
 data "ignition_systemd_unit" "prometheus-machine-role" {
   name    = "prometheus-machine-role.service"
-  content = "${data.template_file.prometheus-machine-role.rendered}"
+  content = data.template_file.prometheus-machine-role.rendered
 }
 
 data "template_file" "prometheus-ro-rootfs" {
-  template = "${file("${path.module}/resources/prometheus-ro-rootfs.service")}"
+  template = file("${path.module}/resources/prometheus-ro-rootfs.service")
 }
 
 data "ignition_systemd_unit" "prometheus-ro-rootfs" {
   name    = "prometheus-ro-rootfs.service"
-  content = "${data.template_file.prometheus-ro-rootfs.rendered}"
+  content = data.template_file.prometheus-ro-rootfs.rendered
 }
 
 data "template_file" "prometheus-ro-rootfs-timer" {
-  template = "${file("${path.module}/resources/prometheus-ro-rootfs.timer")}"
+  template = file("${path.module}/resources/prometheus-ro-rootfs.timer")
 }
 
 data "ignition_systemd_unit" "prometheus-ro-rootfs-timer" {
   name    = "prometheus-ro-rootfs.timer"
-  content = "${data.template_file.prometheus-ro-rootfs-timer.rendered}"
+  content = data.template_file.prometheus-ro-rootfs-timer.rendered
 }
 
 data "ignition_file" "prometheus-ro-rootfs" {
-  mode       = 0755
+  mode       = 493
   filesystem = "root"
   path       = "/opt/bin/prometheus-ro-rootfs"
 
   content {
-    content = "${file("${path.module}/resources/prometheus-ro-rootfs")}"
+    content = file("${path.module}/resources/prometheus-ro-rootfs")
   }
 }
 
 // data.ignition_file.worker-prom-machine-role.id,
 data "ignition_config" "worker" {
-  files = ["${concat(
-    list(
+  files = concat(
+      [
         data.ignition_file.cfssl.id,
         data.ignition_file.cfssljson.id,
         data.ignition_file.cfssl-client-config.id,
@@ -155,12 +155,12 @@ data "ignition_config" "worker" {
         data.ignition_file.worker-sysctl-vm.id,
         data.ignition_file.worker-kubelet-conf.id,
         data.ignition_file.prometheus-ro-rootfs.id,
-    ),
-    var.worker_additional_files
-  )}"]
+      ],
+      var.worker_additional_files
+    )
 
-  systemd = ["${concat(
-    list(
+  systemd = concat(
+      [
         data.ignition_systemd_unit.update-engine.id,
         data.ignition_systemd_unit.locksmithd_worker.id,
         data.ignition_systemd_unit.docker-opts-dropin.id,
@@ -169,8 +169,8 @@ data "ignition_config" "worker" {
         data.ignition_systemd_unit.prometheus-machine-role.id,
         data.ignition_systemd_unit.prometheus-ro-rootfs.id,
         data.ignition_systemd_unit.prometheus-ro-rootfs-timer.id,
-    ),
-    module.kubelet-restarter.systemd_units,
-    var.worker_additional_systemd_units
-  )}"]
+      ],
+      module.kubelet-restarter.systemd_units,
+      var.worker_additional_systemd_units
+    )
 }


### PR DESCRIPTION
This will break compatibility with versions before 0.12, so it shouldn't be merged to master until all modules pulling master are updated to 0.12. It will also require a version bump when it is released.