### PR TITLE
save etcd-member uuid file to /var/run for compatibility between coreos and flatcar

### DIFF
--- a/resources/etcd-member-dropin.conf
+++ b/resources/etcd-member-dropin.conf
@@ -20,7 +20,7 @@ Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/etcd/ssl/ca.pem"
 Environment="ETCD_PEER_CERT_FILE=/etc/etcd/ssl/node.pem"
 Environment="ETCD_PEER_KEY_FILE=/etc/etcd/ssl/node-key.pem"
 Environment="RKT_RUN_ARGS=\
-  --uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid \
+  --uuid-file-save=/var/run/etcd-member-wrapper.uuid \
   --volume etc-etcd,kind=host,source=/etc/etcd,readOnly=true \
   --mount volume=etc-etcd,target=/etc/etcd"
 ExecStartPre=/usr/bin/mkdir -p /etc/etcd


### PR DESCRIPTION
Unless there's some hidden significance to `/var/lib/{coreos,flatcar}`, `/var/run` seems just as reasonable a place to put it with the distinct benefit of being present in both OS's.