### PR TITLE
sys: rm SAN hack including 0 etcd host in all certs

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -17,11 +17,7 @@ data "template_file" "etcd-cfssl-new-cert" {
     org          = ""
     get_ip       = var.get_ip_command[var.cloud_provider]
     get_hostname = var.node_name_command[var.cloud_provider]
-    # workaround for https://github.com/kubernetes/kubernetes/issues/72102
-    # include first member's ip in SAN for all nodes
-    # this replicates kubeadm behaviour to include first node's ip, as kubeadm
-    # generates all certificates on the first node
-    extra_names = join(",", ["etcd.${var.dns_domain}", var.etcd_addresses[0]])
+    extra_names  = join(",", ["etcd.${var.dns_domain}"])
   }
 }
 


### PR DESCRIPTION
Issue resolved in >v1.16.3
https://github.com/kubernetes/kubernetes/issues/72102#issuecomment-542808932