### PR TITLE
save etcd uuid file under /var/lib/{flatcar,coreos}

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -107,6 +107,7 @@ data "template_file" "etcd-member-dropin" {
     index                = count.index
     etcd_initial_cluster = join(",", formatlist("member%s=https://%s:2380", null_resource.etcd_member.*.triggers.index, var.etcd_addresses))
     private_ipv4         = var.etcd_addresses[count.index]
+    uuid_file            = "/var/lib/${var.container_linux_distribution}/etcd-member-wrapper.uuid"
   }
 }
 

--- a/resources/etcd-member-dropin.conf
+++ b/resources/etcd-member-dropin.conf
@@ -20,7 +20,7 @@ Environment="ETCD_PEER_TRUSTED_CA_FILE=/etc/etcd/ssl/ca.pem"
 Environment="ETCD_PEER_CERT_FILE=/etc/etcd/ssl/node.pem"
 Environment="ETCD_PEER_KEY_FILE=/etc/etcd/ssl/node-key.pem"
 Environment="RKT_RUN_ARGS=\
-  --uuid-file-save=/var/run/etcd-member-wrapper.uuid \
+  --uuid-file-save=${uuid_file} \
   --volume etc-etcd,kind=host,source=/etc/etcd,readOnly=true \
   --mount volume=etc-etcd,target=/etc/etcd"
 ExecStartPre=/usr/bin/mkdir -p /etc/etcd

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "container_linux_distribution" {
+  description = "The distribution of Container Linux ('coreos' or 'flatcar')."
+  default     = "flatcar"
+}
+
 variable "enable_container_linux_update-engine" {
   description = "Whether to enable automatic updates for Container Linux."
   default     = true


### PR DESCRIPTION
This matches the rest of the uuid file options in the main service file. I've made it configurable to maintain compatibility between coreos and flatcar while we're running both.