### PR TITLE
sys: set static cpu manager policy

### DIFF
--- a/resources/node-kubelet-conf.yaml
+++ b/resources/node-kubelet-conf.yaml
@@ -11,6 +11,7 @@ authorization:
   mode: AlwaysAllow
 clusterDNS:${cluster_dns}
 clusterDomain: "cluster.local"
+cpuManagerPolicy: "static"
 evictionHard:
   memory.available: "1Gi"
   nodefs.available: "2Gi"


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#configuration

This will allow finance team to deploy "Guaranteed" Cassandra Pods.
Currently when throttled and sharing CPU with other applications,
results in timeouts instead of slower performance.