### PR TITLE
Update cfssl to 1.4.1

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -9,8 +9,8 @@ data "ignition_file" "cfssl" {
   mode       = 493
 
   source {
-    source       = "https://pkg.cfssl.org/R1.2/cfssl_linux-amd64"
-    verification = "sha512-344d58d43aa3948c78eb7e7dafe493c3409f98c73f27cae041c24a7bd14aff07c702d8ab6cdfb15bd6cc55c18b2552f86c5f79a6778f0c277b5e9798d3a38e37"
+    source       = "https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64"
+    verification = "sha512-a3efc1690872be4e71d8edc2f4dbf0085c64e9691eaff0aece176504766ae81176828cd783681634d1262ecc1e079707129261279f98453b654b202feeb4b467"
   }
 }
 
@@ -20,8 +20,8 @@ data "ignition_file" "cfssljson" {
   mode       = 493
 
   source {
-    source       = "https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64"
-    verification = "sha512-b80f19e61e16244422ad3d877e5a7df5c46b34181d264c9c529db8a8fc2999c6a6f7c1fb2dec63e08d311d6657c8fe05af3186b7ff369a866a47d140d393b49b"
+    source       = "https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssljson_1.4.1_linux_amd64"
+    verification = "sha512-a81592c6876c9a0ed480d64b8347b7da2af7047cdf7522f47e808e64efe8635f94826350b11d129c0b22b224517a6c99622d9ceea86e79c476196c3c9333f3fe"
   }
 }
 


### PR DESCRIPTION
To take advantadge or the new healthcheck endpoint