### PR TITLE
Rely on default cfssl port

### DIFF
--- a/resources/cfssl-client-config.json
+++ b/resources/cfssl-client-config.json
@@ -14,6 +14,6 @@
         }
     },
     "remotes": {
-        "server": "${cfssl_server_endpoint}:8888"
+        "server": "${cfssl_server_endpoint}"
     }
 }


### PR DESCRIPTION
Newer cfssl versions have a bug where it doesn't like ip:port as
remotes. Alternatives would be using host:port or protocol:ip:port.

gh issue: https://github.com/cloudflare/cfssl/issues/961