### PR TITLE
Override hostname on kubelet

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -218,6 +218,7 @@ data "template_file" "master-kubelet" {
   vars = {
     kubelet_binary_path = "/opt/bin/kubelet"
     cloud_provider      = var.cloud_provider
+    get_hostname        = var.node_name_command[var.cloud_provider]
   }
 }
 

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -3,6 +3,10 @@ Description=Kubernetes Kubelet
 Requires=docker.service
 After=docker.service
 [Service]
+EnvironmentFile=-/etc/kubernetes/config/kubeletenv
+ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/config
+ExecStartPre=/usr/bin/touch /etc/kubernetes/config/kubeletenv
+ExecStartPre=/bin/sh -c 'echo "NODE_HOSTNAME=$(${get_hostname})" >> /etc/kubernetes/config/kubeletenv'
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
@@ -18,6 +22,7 @@ ExecStartPre=/sbin/sysctl -w net.ipv4.tcp_retries2=8
 ExecStartPre=/sbin/sysctl -w fs.inotify.max_user_watches=524288
 ExecStart=${kubelet_binary_path} \
   --config=/etc/kubernetes/config/master-kubelet-conf.yaml \
+  --hostname-override="$${NODE_HOSTNAME}" \
   --kubeconfig=/var/lib/kubelet/kubeconfig \
   --node-labels=role=master \
   --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -5,7 +5,7 @@ After=docker.service
 [Service]
 EnvironmentFile=-/etc/kubernetes/config/kubeletenv
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/config
-ExecStartPre=/usr/bin/touch /etc/kubernetes/config/kubeletenv
+ExecStartPre=/usr/bin/truncate -s0 /etc/kubernetes/config/kubeletenv
 ExecStartPre=/bin/sh -c 'echo "NODE_HOSTNAME=$(${get_hostname})" >> /etc/kubernetes/config/kubeletenv'
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers

--- a/resources/node-kubelet.service
+++ b/resources/node-kubelet.service
@@ -3,6 +3,10 @@ Description=Kubernetes Kubelet
 Requires=docker.service
 After=docker.service
 [Service]
+EnvironmentFile=-/etc/kubernetes/config/kubeletenv
+ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/config
+ExecStartPre=/usr/bin/touch /etc/kubernetes/config/kubeletenv
+ExecStartPre=/bin/sh -c 'echo "NODE_HOSTNAME=$(${get_hostname})" >> /etc/kubernetes/config/kubeletenv'
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
@@ -24,6 +28,7 @@ ExecStart=${kubelet_binary_path} \
   --config=/etc/kubernetes/config/node-kubelet-conf.yaml \
   --container-runtime=docker \
   --exit-on-lock-contention \
+  --hostname-override="$${NODE_HOSTNAME}" \
   --kubeconfig=/var/lib/kubelet/kubeconfig \
   --network-plugin=cni \
   --node-labels=${labels} \

--- a/resources/node-kubelet.service
+++ b/resources/node-kubelet.service
@@ -5,7 +5,7 @@ After=docker.service
 [Service]
 EnvironmentFile=-/etc/kubernetes/config/kubeletenv
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/config
-ExecStartPre=/usr/bin/touch /etc/kubernetes/config/kubeletenv
+ExecStartPre=/usr/bin/truncate -s0 /etc/kubernetes/config/kubeletenv
 ExecStartPre=/bin/sh -c 'echo "NODE_HOSTNAME=$(${get_hostname})" >> /etc/kubernetes/config/kubeletenv'
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers

--- a/storage-node.tf
+++ b/storage-node.tf
@@ -9,6 +9,7 @@ data "template_file" "storage-node-kubelet" {
   vars = {
     kubelet_binary_path = "/opt/bin/kubelet"
     cloud_provider      = var.cloud_provider
+    get_hostname        = var.node_name_command[var.cloud_provider]
     labels              = "role=storage-node,node.longhorn.io/create-default-disk=true"
     taints              = "storage=longhorn:NoSchedule"
   }

--- a/worker.tf
+++ b/worker.tf
@@ -9,6 +9,7 @@ data "template_file" "worker-kubelet" {
   vars = {
     kubelet_binary_path = "/opt/bin/kubelet"
     cloud_provider      = var.cloud_provider
+    get_hostname        = var.node_name_command[var.cloud_provider]
     labels              = "role=worker"
     taints              = ""
   }


### PR DESCRIPTION
kubelet gets the hostname from the system which on coreos does not
include the domain name (it's the short hostname and not the FQDN). This
causes the `kubernetes.io/hostname` label to mismatch the node name and
is problematic when using Service Topology and potentially other
features that use this label.