### PR TITLE
Add registry mirror config to dockerd

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -81,6 +81,6 @@ data "ignition_file" "docker_daemon_json" {
   path       = "/etc/docker/daemon.json"
 
   content {
-    content = file("${path.module}/resources/daemon.json")
+    content = file("${path.module}/resources/docker_daemon.json")
   }
 }

--- a/common.tf
+++ b/common.tf
@@ -74,3 +74,13 @@ data "ignition_directory" "journald" {
   filesystem = "root"
   path       = "/var/log/journal"
 }
+
+data "ignition_file" "docker_daemon_json" {
+  mode       = 493
+  filesystem = "root"
+  path       = "/etc/docker/daemon.json"
+
+  source {
+    content = file("${path.module}/resources/daemon.json")
+  }
+}

--- a/common.tf
+++ b/common.tf
@@ -80,7 +80,7 @@ data "ignition_file" "docker_daemon_json" {
   filesystem = "root"
   path       = "/etc/docker/daemon.json"
 
-  source {
+  content {
     content = file("${path.module}/resources/daemon.json")
   }
 }

--- a/master.tf
+++ b/master.tf
@@ -430,6 +430,7 @@ data "ignition_config" "master" {
       data.ignition_file.cfssl.rendered,
       data.ignition_file.cfssljson.rendered,
       data.ignition_file.cfssl-client-config.rendered,
+      data.ignition_file.docker_daemon_json.rendered,
       data.ignition_file.master-cfssl-new-node-cert.rendered,
       data.ignition_file.master-cfssl-new-apiserver-cert.rendered,
       data.ignition_file.master-cfssl-new-apiserver-kubelet-client-cert.rendered,

--- a/resources/docker_daemon.json
+++ b/resources/docker_daemon.json
@@ -1,0 +1,3 @@
+{
+  "registry-mirrors": ["http://localhost:30001"]
+}

--- a/worker.tf
+++ b/worker.tf
@@ -42,6 +42,7 @@ data "ignition_config" "worker" {
       data.ignition_file.cfssl.rendered,
       data.ignition_file.cfssljson.rendered,
       data.ignition_file.cfssl-client-config.rendered,
+      data.ignition_file.docker_daemon_json.rendered,
       data.ignition_file.node-cfssl-new-cert.rendered,
       data.ignition_file.node-kubelet-cfssl-new-cert.rendered,
       data.ignition_file.kubelet.rendered,


### PR DESCRIPTION
Since dockerhub is introducing rate limiting, we can use registry mirror
with a Pro account to avoid it
