### PR TITLE
Use containerd as the container runtime for Kubernetes

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -201,6 +201,7 @@ data "ignition_config" "cfssl" {
       data.ignition_file.cfssl-proxy-csr-json.rendered,
       data.ignition_file.cfssl-nginx-conf.rendered,
       data.ignition_file.cfssl-nginx-auth.rendered,
+      data.ignition_file.docker-config.rendered,
       data.ignition_file.format-and-mount.rendered,
     ],
     var.cfssl_additional_files

--- a/common.tf
+++ b/common.tf
@@ -88,3 +88,21 @@ data "ignition_file" "docker_daemon_json" {
     content = file("${path.module}/resources/docker_daemon.json")
   }
 }
+
+data "ignition_file" "containerd-config" {
+  filesystem = "root"
+  path       = "/etc/containerd/config.toml"
+  mode       = 384
+  content {
+    content = file("${path.module}/resources/containerd-config.toml")
+  }
+}
+
+data "ignition_systemd_unit" "containerd-dropin" {
+  name = "containerd.service"
+
+  dropin {
+    name    = "10-custom-options.conf"
+    content = file("${path.module}/resources/containerd-dropin.conf")
+  }
+}

--- a/common.tf
+++ b/common.tf
@@ -89,6 +89,42 @@ data "ignition_file" "docker_daemon_json" {
   }
 }
 
+data "ignition_file" "docker-config" {
+  mode       = 384
+  filesystem = "root"
+  path       = "/root/.docker/config.json"
+
+  content {
+    content = jsonencode(
+      {
+        auths = {
+          "https://index.docker.io/v1/" = {
+            auth = base64encode("${var.dockerhub_username}:${var.dockerhub_password}")
+          }
+        }
+      }
+    )
+  }
+}
+
+data "ignition_file" "kubelet-docker-config" {
+  mode       = 384
+  filesystem = "root"
+  path       = "/var/lib/kubelet/config.json"
+
+  content {
+    content = jsonencode(
+      {
+        auths = {
+          "https://index.docker.io/v1/" = {
+            auth = base64encode("${var.dockerhub_username}:${var.dockerhub_password}")
+          }
+        }
+      }
+    )
+  }
+}
+
 data "ignition_file" "containerd-config" {
   filesystem = "root"
   path       = "/etc/containerd/config.toml"

--- a/common.tf
+++ b/common.tf
@@ -97,6 +97,7 @@ data "ignition_file" "containerd-config" {
     content = templatefile("${path.module}/resources/containerd-config.toml",
       {
         dockerhub_mirror_endpoint = var.dockerhub_mirror_endpoint,
+        dockerhub_auth            = base64encode("${var.dockerhub_username}:${var.dockerhub_password}"),
       }
     )
   }

--- a/common.tf
+++ b/common.tf
@@ -110,3 +110,30 @@ data "ignition_systemd_unit" "containerd-dropin" {
     content = file("${path.module}/resources/containerd-dropin.conf")
   }
 }
+
+data "ignition_file" "crictl" {
+  mode       = 420
+  filesystem = "root"
+  path       = "/opt/crictl.tar.gz"
+
+  source {
+    source       = "https://github.com/kubernetes-sigs/cri-tools/releases/download/${var.crictl_version}/crictl-${var.crictl_version}-linux-amd64.tar.gz"
+    verification = var.crictl_verification
+  }
+}
+
+data "ignition_systemd_unit" "prepare-crictl" {
+  name = "prepare-crictl.service"
+
+  content = file("${path.module}/resources/prepare-crictl.service")
+}
+
+data "ignition_file" "crictl-config" {
+  filesystem = "root"
+  path       = "/etc/crictl.yaml"
+  mode       = 384
+
+  content {
+    content = file("${path.module}/resources/crictl.yaml")
+  }
+}

--- a/common.tf
+++ b/common.tf
@@ -75,17 +75,17 @@ data "ignition_directory" "journald" {
   path       = "/var/log/journal"
 }
 
-# We are using default docker daemon bridge address here (172.17.0.1) to address
-# registry mirror. Ideally we would use localhost, but there is a bug with IPVS
-# and using localhost:<nodeport> ::
-# https://github.com/kubernetes/kubernetes/issues/67730
 data "ignition_file" "docker_daemon_json" {
   mode       = 493
   filesystem = "root"
   path       = "/etc/docker/daemon.json"
 
   content {
-    content = file("${path.module}/resources/docker_daemon.json")
+    content = templatefile("${path.module}/resources/docker_daemon.json",
+      {
+        dockerhub_mirror_endpoint = var.dockerhub_mirror_endpoint,
+      }
+    )
   }
 }
 
@@ -94,7 +94,11 @@ data "ignition_file" "containerd-config" {
   path       = "/etc/containerd/config.toml"
   mode       = 384
   content {
-    content = file("${path.module}/resources/containerd-config.toml")
+    content = templatefile("${path.module}/resources/containerd-config.toml",
+      {
+        dockerhub_mirror_endpoint = var.dockerhub_mirror_endpoint,
+      }
+    )
   }
 }
 

--- a/etcd.tf
+++ b/etcd.tf
@@ -143,7 +143,8 @@ data "ignition_config" "etcd" {
       element(data.ignition_file.etcd-cfssl-new-cert.*.rendered, count.index),
       data.ignition_file.etcd-prom-machine-role.rendered,
       element(data.ignition_file.etcdctl-wrapper.*.rendered, count.index),
-      data.ignition_file.format-and-mount.rendered
+      data.ignition_file.format-and-mount.rendered,
+      data.ignition_file.docker-config.rendered,
     ],
     var.etcd_additional_files
   )

--- a/master.tf
+++ b/master.tf
@@ -451,6 +451,8 @@ data "ignition_config" "master" {
       data.ignition_file.containerd-config.rendered,
       data.ignition_file.crictl.rendered,
       data.ignition_file.crictl-config.rendered,
+      data.ignition_file.docker-config.rendered,
+      data.ignition_file.kubelet-docker-config.rendered,
     ],
     var.master_additional_files,
     [local.kube_controller_additional_config]

--- a/master.tf
+++ b/master.tf
@@ -448,6 +448,7 @@ data "ignition_config" "master" {
       data.ignition_file.kube-controller-manager.rendered,
       data.ignition_file.kubelet.rendered,
       data.ignition_file.master-kubelet-conf.rendered,
+      data.ignition_file.containerd-config.rendered,
     ],
     var.master_additional_files,
     [local.kube_controller_additional_config]
@@ -459,6 +460,7 @@ data "ignition_config" "master" {
       data.ignition_systemd_unit.locksmithd_master.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
       data.ignition_systemd_unit.master-kubelet.rendered,
+      data.ignition_systemd_unit.containerd-dropin.rendered,
     ],
     module.cert-refresh-master.systemd_units,
     var.master_additional_systemd_units,

--- a/master.tf
+++ b/master.tf
@@ -449,6 +449,8 @@ data "ignition_config" "master" {
       data.ignition_file.kubelet.rendered,
       data.ignition_file.master-kubelet-conf.rendered,
       data.ignition_file.containerd-config.rendered,
+      data.ignition_file.crictl.rendered,
+      data.ignition_file.crictl-config.rendered,
     ],
     var.master_additional_files,
     [local.kube_controller_additional_config]
@@ -461,6 +463,7 @@ data "ignition_config" "master" {
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
       data.ignition_systemd_unit.master-kubelet.rendered,
       data.ignition_systemd_unit.containerd-dropin.rendered,
+      data.ignition_systemd_unit.prepare-crictl.rendered,
     ],
     module.cert-refresh-master.systemd_units,
     var.master_additional_systemd_units,

--- a/modules/cert-refresh-node/main.tf
+++ b/modules/cert-refresh-node/main.tf
@@ -8,7 +8,7 @@ data "ignition_systemd_unit" "cert-refresh" {
   content = <<EOS
 [Unit]
 Description=Fetch new certificates from cfssl server and restart components to reload certs
-Requires=docker.service
+Requires=containerd.service
 After=network-online.target
 [Service]
 Type=oneshot

--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -36,3 +36,8 @@ disabled_plugins = []
 
 [plugins."io.containerd.grpc.v1.cri".registry.auths."registry-1.docker.io"]
   auth = "${dockerhub_auth}"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+  runtime_type = "io.containerd.runc.v2"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+    SystemdCgroup = true

--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -32,3 +32,6 @@ shim_debug = true
 
 [plugins.cri.registry.mirrors."docker.io"]
   endpoint = ["${dockerhub_mirror_endpoint}"]
+
+[plugins.cri.registry.auths."registry-1.docker.io"]
+  auth = "${dockerhub_auth}"

--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -1,4 +1,5 @@
 # adapted from: https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-from-docker-to-containerd-for-kubernetes/
+version = 2
 
 # persistent data location
 root = "/var/lib/containerd"
@@ -13,25 +14,25 @@ disabled_plugins = []
 
 # grpc configuration
 [grpc]
-address = "/run/docker/libcontainerd/docker-containerd.sock"
-# socket uid
-uid = 0
-# socket gid
-gid = 0
+  address = "/run/docker/libcontainerd/docker-containerd.sock"
+  # socket uid
+  uid = 0
+  # socket gid
+  gid = 0
 
-[plugins.linux]
-# shim binary name/path
-shim = "containerd-shim"
-# runtime binary name/path
-runtime = "runc"
-# do not use a shim when starting containers, saves on memory but
-# live restore is not supported
-no_shim = false
-# display shim logs in the containerd daemon's log output
-shim_debug = true
+[plugins."io.containerd.runtime.v1.linux"]
+  # shim binary name/path
+  shim = "containerd-shim"
+  # runtime binary name/path
+  runtime = "runc"
+  # do not use a shim when starting containers, saves on memory but
+  # live restore is not supported
+  no_shim = false
+  # display shim logs in the containerd daemon's log output
+  shim_debug = true
 
-[plugins.cri.registry.mirrors."docker.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
   endpoint = ["${dockerhub_mirror_endpoint}"]
 
-[plugins.cri.registry.auths."registry-1.docker.io"]
+[plugins."io.containerd.grpc.v1.cri".registry.auths."registry-1.docker.io"]
   auth = "${dockerhub_auth}"

--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -29,3 +29,6 @@ runtime = "runc"
 no_shim = false
 # display shim logs in the containerd daemon's log output
 shim_debug = true
+
+[plugins.cri.registry.mirrors."docker.io"]
+  endpoint = ["${dockerhub_mirror_endpoint}"]

--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -1,0 +1,31 @@
+# adapted from: https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-from-docker-to-containerd-for-kubernetes/
+
+# persistent data location
+root = "/var/lib/containerd"
+# runtime state information
+state = "/run/docker/libcontainerd/containerd"
+# set containerd as a subreaper on linux when it is not running as PID 1
+subreaper = true
+# set containerd's OOM score
+oom_score = -999
+# CRI plugin listens on a TCP port by default
+disabled_plugins = []
+
+# grpc configuration
+[grpc]
+address = "/run/docker/libcontainerd/docker-containerd.sock"
+# socket uid
+uid = 0
+# socket gid
+gid = 0
+
+[plugins.linux]
+# shim binary name/path
+shim = "containerd-shim"
+# runtime binary name/path
+runtime = "runc"
+# do not use a shim when starting containers, saves on memory but
+# live restore is not supported
+no_shim = false
+# display shim logs in the containerd daemon's log output
+shim_debug = true

--- a/resources/containerd-dropin.conf
+++ b/resources/containerd-dropin.conf
@@ -1,0 +1,4 @@
+[Service]
+Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
+ExecStart=
+ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}

--- a/resources/crictl.yaml
+++ b/resources/crictl.yaml
@@ -1,0 +1,1 @@
+runtime-endpoint: unix:///run/docker/libcontainerd/docker-containerd.sock

--- a/resources/docker_daemon.json
+++ b/resources/docker_daemon.json
@@ -1,3 +1,3 @@
 {
-  "registry-mirrors": ["http://172.17.0.1:30001"]
+  "registry-mirrors": ["${dockerhub_mirror_endpoint}"]
 }

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -26,7 +26,8 @@ ExecStart=${kubelet_binary_path} \
   --kubeconfig=/var/lib/kubelet/kubeconfig \
   --node-labels=role=master \
   --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
-  --container-runtime=docker \
+  --container-runtime=remote \
+  --container-runtime-endpoint=unix:///run/docker/libcontainerd/docker-containerd.sock \
   --network-plugin=cni \
   --cni-bin-dir=/opt/cni/bin \
   --cni-conf-dir=/etc/cni/net.d \

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Kubernetes Kubelet
-Requires=docker.service
-After=docker.service
+Requires=containerd.service
+After=containerd.service
 [Service]
 EnvironmentFile=-/etc/kubernetes/config/kubeletenv
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/config

--- a/resources/node-kubelet.service
+++ b/resources/node-kubelet.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Kubernetes Kubelet
-Requires=docker.service
-After=docker.service
+Requires=containerd.service
+After=containerd.service
 [Service]
 EnvironmentFile=-/etc/kubernetes/config/kubeletenv
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/config

--- a/resources/node-kubelet.service
+++ b/resources/node-kubelet.service
@@ -26,7 +26,8 @@ ExecStart=${kubelet_binary_path} \
   --cni-bin-dir=/opt/cni/bin \
   --cni-conf-dir=/etc/cni/net.d \
   --config=/etc/kubernetes/config/node-kubelet-conf.yaml \
-  --container-runtime=docker \
+  --container-runtime=remote \
+  --container-runtime-endpoint=unix:///run/docker/libcontainerd/docker-containerd.sock \
   --exit-on-lock-contention \
   --hostname-override="$${NODE_HOSTNAME}" \
   --kubeconfig=/var/lib/kubelet/kubeconfig \

--- a/resources/prepare-crictl.service
+++ b/resources/prepare-crictl.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Unpack crictl to /opt/bin
+ConditionPathExists=!/opt/bin/crictl
+[Service]
+Type=oneshot
+RemainAfterExit=true
+Restart=on-failure
+ExecStartPre=/usr/bin/mkdir -p /opt/bin
+ExecStartPre=/usr/bin/tar -v --extract --file /opt/crictl.tar.gz --directory /opt/ --no-same-owner
+ExecStartPre=/usr/bin/rm /opt/crictl.tar.gz
+ExecStart=/usr/bin/sh -c "mv /opt/crictl /opt/bin/"
+[Install]
+WantedBy=multi-user.target

--- a/variables.tf
+++ b/variables.tf
@@ -191,6 +191,14 @@ variable "dockerhub_mirror_endpoint" {
   default     = "http://172.17.0.1:30001"
 }
 
+variable "dockerhub_username" {
+  description = "Docker Hub user"
+}
+
+variable "dockerhub_password" {
+  description = "Docker Hub password"
+}
+
 variable "crictl_version" {
   description = "The version of the crictl release to install"
   default     = "v1.19.0"

--- a/variables.tf
+++ b/variables.tf
@@ -182,6 +182,15 @@ variable "etcd_data_volumeids" {
   type = list(string)
 }
 
+# We are using default docker daemon bridge address here (172.17.0.1) to address
+# registry mirror. Ideally we would use localhost, but there is a bug with IPVS
+# and using localhost:<nodeport> ::
+# https://github.com/kubernetes/kubernetes/issues/67730
+variable "dockerhub_mirror_endpoint" {
+  description = "DockerHub mirror endpoint"
+  default     = "http://172.17.0.1:30001"
+}
+
 variable "feature_gates" {
   description = "https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -191,6 +191,16 @@ variable "dockerhub_mirror_endpoint" {
   default     = "http://172.17.0.1:30001"
 }
 
+variable "crictl_version" {
+  description = "The version of the crictl release to install"
+  default     = "v1.19.0"
+}
+
+variable "crictl_verification" {
+  description = "Hash to verify crictl release tar.gz"
+  default     = "sha512-fbbb34a1667bcf94df911a92ab6b70a9d2b34da967244a222f288bf0135c587cbfdcc89deedc5afd1823e109921df9caaa4e9ff9cc39e55a9b8cdea8eb6ebe72"
+}
+
 variable "feature_gates" {
   description = "https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/"
   type        = map(string)

--- a/worker.tf
+++ b/worker.tf
@@ -53,6 +53,8 @@ data "ignition_config" "worker" {
       data.ignition_file.containerd-config.rendered,
       data.ignition_file.crictl.rendered,
       data.ignition_file.crictl-config.rendered,
+      data.ignition_file.docker-config.rendered,
+      data.ignition_file.kubelet-docker-config.rendered,
     ],
     var.worker_additional_files
   )

--- a/worker.tf
+++ b/worker.tf
@@ -50,6 +50,7 @@ data "ignition_config" "worker" {
       data.ignition_file.node-sysctl-vm.rendered,
       data.ignition_file.node-kubelet-conf.rendered,
       data.ignition_file.prometheus-ro-rootfs.rendered,
+      data.ignition_file.containerd-config.rendered,
     ],
     var.worker_additional_files
   )
@@ -64,6 +65,7 @@ data "ignition_config" "worker" {
       data.ignition_systemd_unit.prometheus-machine-role-worker.rendered,
       data.ignition_systemd_unit.prometheus-ro-rootfs.rendered,
       data.ignition_systemd_unit.prometheus-ro-rootfs-timer.rendered,
+      data.ignition_systemd_unit.containerd-dropin.rendered,
     ],
     module.cert-refresh-node.systemd_units,
     var.worker_additional_systemd_units

--- a/worker.tf
+++ b/worker.tf
@@ -51,6 +51,8 @@ data "ignition_config" "worker" {
       data.ignition_file.node-kubelet-conf.rendered,
       data.ignition_file.prometheus-ro-rootfs.rendered,
       data.ignition_file.containerd-config.rendered,
+      data.ignition_file.crictl.rendered,
+      data.ignition_file.crictl-config.rendered,
     ],
     var.worker_additional_files
   )
@@ -66,6 +68,7 @@ data "ignition_config" "worker" {
       data.ignition_systemd_unit.prometheus-ro-rootfs.rendered,
       data.ignition_systemd_unit.prometheus-ro-rootfs-timer.rendered,
       data.ignition_systemd_unit.containerd-dropin.rendered,
+      data.ignition_systemd_unit.prepare-crictl.rendered,
     ],
     module.cert-refresh-node.systemd_units,
     var.worker_additional_systemd_units


### PR DESCRIPTION
This PR replaces Docker with containerd as the container-runtime for Kubernetes. Docker compatability is maintained, which allows other containers to be ran with `docker`.

It's configured as instructed here:
https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-from-docker-to-containerd-for-kubernetes/

with the following additions:
- Containerd is configured to pull docker.io images from our mirror
- Containerd is configured to use docker hub credentials to auth to docker.io (as a fallback for when the mirror is down)
- Install crictl, which is a useful cli for interacting with the Kubernetes CRI interface and is used instead of docker in the cert-refresh service for stopping control-plane containers

I've also added configuration of docker hub auth for docker and kubelet, which was previously done outside of this module. Seen as we're doing it for containerd in the module, I figured we should do the same for the others.