### PR TITLE
Improvements and fixes for containerd

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -201,6 +201,7 @@ data "ignition_config" "cfssl" {
       data.ignition_file.cfssl-proxy-csr-json.rendered,
       data.ignition_file.cfssl-nginx-conf.rendered,
       data.ignition_file.cfssl-nginx-auth.rendered,
+      data.ignition_file.containerd-config.rendered,
       data.ignition_file.docker-config.rendered,
       data.ignition_file.format-and-mount.rendered,
     ],
@@ -216,6 +217,7 @@ data "ignition_config" "cfssl" {
       data.ignition_systemd_unit.cfssl.rendered,
       data.ignition_systemd_unit.cfssl-nginx.rendered,
       data.ignition_systemd_unit.cfssl-disk-mounter.rendered,
+      data.ignition_systemd_unit.containerd-dropin.rendered,
     ],
     module.cfssl-restarter.systemd_units,
     var.cfssl_additional_systemd_units

--- a/cfssl.tf
+++ b/cfssl.tf
@@ -190,6 +190,7 @@ module "cfssl-restarter" {
 data "ignition_config" "cfssl" {
   files = concat(
     [
+      data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl.rendered,
       data.ignition_file.cfssljson.rendered,
       data.ignition_file.cfssl-server-config.rendered,

--- a/common.tf
+++ b/common.tf
@@ -174,3 +174,15 @@ data "ignition_file" "crictl-config" {
     content = file("${path.module}/resources/crictl.yaml")
   }
 }
+
+data "ignition_file" "bashrc" {
+  filesystem = "root"
+  path       = "/home/core/.bashrc"
+  mode       = 420
+  uid        = 500 # core
+  gid        = 500 # core
+
+  content {
+    content = file("${path.module}/resources/bashrc")
+  }
+}

--- a/etcd.tf
+++ b/etcd.tf
@@ -136,6 +136,7 @@ data "ignition_config" "etcd" {
 
   files = concat(
     [
+      data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl.rendered,
       data.ignition_file.cfssljson.rendered,
       data.ignition_file.cfssl-client-config.rendered,

--- a/etcd.tf
+++ b/etcd.tf
@@ -139,6 +139,7 @@ data "ignition_config" "etcd" {
       data.ignition_file.cfssl.rendered,
       data.ignition_file.cfssljson.rendered,
       data.ignition_file.cfssl-client-config.rendered,
+      data.ignition_file.containerd-config.rendered,
       data.ignition_file.etcd.rendered,
       element(data.ignition_file.etcd-cfssl-new-cert.*.rendered, count.index),
       data.ignition_file.etcd-prom-machine-role.rendered,
@@ -156,7 +157,8 @@ data "ignition_config" "etcd" {
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
       data.ignition_systemd_unit.node-exporter.rendered,
       element(data.ignition_systemd_unit.etcd-member.*.rendered, count.index),
-      element(data.ignition_systemd_unit.etcd-disk-mounter.*.rendered, count.index)
+      element(data.ignition_systemd_unit.etcd-disk-mounter.*.rendered, count.index),
+      data.ignition_systemd_unit.containerd-dropin.rendered,
     ],
     module.etcd-cert-fetcher.systemd_units,
     var.etcd_additional_systemd_units

--- a/master.tf
+++ b/master.tf
@@ -453,6 +453,7 @@ data "ignition_config" "master" {
       data.ignition_file.crictl-config.rendered,
       data.ignition_file.docker-config.rendered,
       data.ignition_file.kubelet-docker-config.rendered,
+      data.ignition_file.bashrc.rendered,
     ],
     var.master_additional_files,
     [local.kube_controller_additional_config]

--- a/resources/bashrc
+++ b/resources/bashrc
@@ -1,0 +1,18 @@
+# /etc/skel/.bashrc
+#
+# This file is sourced by all *interactive* bash shells on startup,
+# including some apparently interactive shells such as scp and rcp
+# that can't tolerate any output.  So make sure this doesn't display
+# anything or bad things will happen !
+
+
+# Test for an interactive shell.  There is no need to set anything
+# past this point for scp and rcp, and it's important to refrain from
+# outputting anything in those cases.
+if [[ $- != *i* ]] ; then
+        # Shell is non-interactive.  Be done now!
+        return
+fi
+
+# Put your fun stuff here.
+alias crictl="sudo crictl"

--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -1,4 +1,6 @@
 # adapted from: https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-from-docker-to-containerd-for-kubernetes/
+
+# UW: switch to version 2 syntax
 version = 2
 
 # persistent data location
@@ -14,7 +16,12 @@ disabled_plugins = []
 
 # grpc configuration
 [grpc]
-  address = "/run/docker/libcontainerd/docker-containerd.sock"
+  # UW: override the custom socket location shipped with flatcar in
+  # favour of the containerd default. This plays more nicely with the defaults
+  # of things like ctr and kubelet's cadvisor.
+  #
+  # We pass this socket location to dockerd to maintain docker compatibility.
+  address = "/run/containerd/containerd.sock"
   # socket uid
   uid = 0
   # socket gid

--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -36,8 +36,3 @@ disabled_plugins = []
 
 [plugins."io.containerd.grpc.v1.cri".registry.auths."registry-1.docker.io"]
   auth = "${dockerhub_auth}"
-
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-  runtime_type = "io.containerd.runc.v2"
-  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
-    SystemdCgroup = true

--- a/resources/crictl.yaml
+++ b/resources/crictl.yaml
@@ -1,1 +1,1 @@
-runtime-endpoint: unix:///run/docker/libcontainerd/docker-containerd.sock
+runtime-endpoint: unix:///run/containerd/containerd.sock

--- a/resources/docker-dropin.conf
+++ b/resources/docker-dropin.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment=DOCKER_OPTS="--exec-opt native.cgroupdriver=systemd --log-opt max-size=100m --log-opt max-file=1"
+Environment=DOCKER_OPTS="--log-opt max-size=100m --log-opt max-file=1"

--- a/resources/docker-dropin.conf
+++ b/resources/docker-dropin.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment=DOCKER_OPTS="--log-opt max-size=100m --log-opt max-file=1"
+Environment=DOCKER_OPTS="--containerd=/run/containerd/containerd.sock --log-opt max-size=100m --log-opt max-file=1"

--- a/resources/master-kubelet-conf.yaml
+++ b/resources/master-kubelet-conf.yaml
@@ -17,4 +17,3 @@ serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"
 tlsCertFile: "/etc/kubernetes/ssl/kubelet.pem"
 tlsPrivateKeyFile: "/etc/kubernetes/ssl/kubelet-key.pem"
-cgroupDriver: systemd

--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -27,7 +27,7 @@ ExecStart=${kubelet_binary_path} \
   --node-labels=role=master \
   --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
   --container-runtime=remote \
-  --container-runtime-endpoint=unix:///run/docker/libcontainerd/docker-containerd.sock \
+  --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
   --network-plugin=cni \
   --cni-bin-dir=/opt/cni/bin \
   --cni-conf-dir=/etc/cni/net.d \

--- a/resources/node-kubelet-conf.yaml
+++ b/resources/node-kubelet-conf.yaml
@@ -17,7 +17,6 @@ serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"
 tlsCertFile: "/etc/kubernetes/ssl/kubelet.pem"
 tlsPrivateKeyFile: "/etc/kubernetes/ssl/kubelet-key.pem"
-cgroupDriver: systemd
 
 # Resource allocation
 cpuManagerPolicy: "static"

--- a/resources/node-kubelet.service
+++ b/resources/node-kubelet.service
@@ -27,7 +27,7 @@ ExecStart=${kubelet_binary_path} \
   --cni-conf-dir=/etc/cni/net.d \
   --config=/etc/kubernetes/config/node-kubelet-conf.yaml \
   --container-runtime=remote \
-  --container-runtime-endpoint=unix:///run/docker/libcontainerd/docker-containerd.sock \
+  --container-runtime-endpoint=unix:///run/containerd/containerd.sock \
   --exit-on-lock-contention \
   --hostname-override="$${NODE_HOSTNAME}" \
   --kubeconfig=/var/lib/kubelet/kubeconfig \

--- a/worker.tf
+++ b/worker.tf
@@ -55,6 +55,7 @@ data "ignition_config" "worker" {
       data.ignition_file.crictl-config.rendered,
       data.ignition_file.docker-config.rendered,
       data.ignition_file.kubelet-docker-config.rendered,
+      data.ignition_file.bashrc.rendered,
     ],
     var.worker_additional_files
   )


### PR DESCRIPTION
- Turn off systemd cgroups in kubelet, containerd and docker. This was contributing to the 'runc hang' we were previously seeing in docker and which started when we enabled it in containerd.
- Use the default containerd socket address. The integrated cadvisor in kubelet has an issue where it won't scrape metrics from a custom location. Some tools, like `ctr` default to the standard address as well.
- Alias `crictl` to `sudo crictl` for the core user to save on some keystrokes