### PR TITLE
Restart cert-refresh.service on failure

### DIFF
--- a/modules/cert-refresh-master/main.tf
+++ b/modules/cert-refresh-master/main.tf
@@ -25,6 +25,7 @@ ExecStart=-/bin/sh -c "/opt/bin/crictl stop $(/opt/bin/crictl ps -q --label io.k
 ExecStart=-/bin/sh -c "/opt/bin/crictl stop $(/opt/bin/crictl ps -q --label io.kubernetes.container.name=kube-apiserver)"
 ExecStart=-/bin/sh -c "/opt/bin/crictl stop $(/opt/bin/crictl ps -q --label io.kubernetes.container.name=kube-scheduler)"
 ExecStart=/usr/bin/systemctl try-restart kubelet.service
+Restart=on-failure
 [Install]
 WantedBy=multi-user.target
 EOS

--- a/modules/cert-refresh-node/main.tf
+++ b/modules/cert-refresh-node/main.tf
@@ -17,6 +17,7 @@ ExecStart=/opt/bin/cfssl-new-kubelet-cert
 # Hack to reload certs on control plane tier
 #  https://github.com/kubernetes/kubernetes/issues/46287
 ExecStart=/usr/bin/systemctl try-restart kubelet.service
+Restart=on-failure
 [Install]
 WantedBy=multi-user.target
 EOS


### PR DESCRIPTION
Saw sporadic cases on merit where the service was failing on startup due to
"network unreachable", even though we seem to have a network.online dependency.
A simple `systemctl restart cert-refresh.service` was enough to start the
service fine and fetch certs.