### PR TITLE
etcd: stagger reboot windows

### DIFF
--- a/resources/locksmithd-dropin.conf
+++ b/resources/locksmithd-dropin.conf
@@ -1,0 +1,3 @@
+[Service]
+Environment=LOCKSMITHD_REBOOT_WINDOW_START=${reboot_window_start}
+Environment=LOCKSMITHD_REBOOT_WINDOW_LENGTH=${reboot_window_length}


### PR DESCRIPTION
Locksmithd will trigger a reboot as soon as the update-engine signals that an update has been downloaded and installed. Without a process to orchestrate these reboots, there's a chance that the reboots could overlap and cause an availability issue for the etcd cluster.

This doesn't seem to be an issue in AWS/GCP, probably because the VMs reboot quickly, making an overlap uncommon. In Merit, however, nodes can take up to 5 or 10 minutes to reboot, making overlaps a distinct likelihood.

Rather than use the etcd-lock strategy, which doesn't seem to be compatibile with our version of etcd, we can avoid clashes by assigning each node its own daily reboot window.