### PR TITLE
Make containerd log level configurable

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -134,6 +134,7 @@ data "ignition_file" "containerd-config" {
       {
         dockerhub_mirror_endpoint = var.dockerhub_mirror_endpoint,
         dockerhub_auth            = base64encode("${var.dockerhub_username}:${var.dockerhub_password}"),
+        containerd_log_level      = var.containerd_log_level
       }
     )
   }

--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -43,3 +43,6 @@ disabled_plugins = []
 
 [plugins."io.containerd.grpc.v1.cri".registry.auths."registry-1.docker.io"]
   auth = "${dockerhub_auth}"
+
+[debug]
+  level = "${containerd_log_level}"

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,11 @@ variable "enable_container_linux_locksmithd_worker" {
   default     = true
 }
 
+variable "containerd_log_level" {
+  description = "Log level for the containerd daemon (debug, info, warn, error, fatal, panic)"
+  default     = "warn"
+}
+
 variable "dns_domain" {
   description = "The domain under which this cluster's DNS records are set (cluster-name.example.com)."
 }


### PR DESCRIPTION
Note that this only affects containerd, but the "shim_debug" option will
still log "debug" messages. Those don't seem too verbose so leaving
them on