### PR TITLE
Use community-terraform-providers/ignition

### DIFF
--- a/modules/cert-fetcher-etcd/versions.tf
+++ b/modules/cert-fetcher-etcd/versions.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 0.13"
   required_providers {
     ignition = {
-      source = "terraform-providers/ignition"
+      source  = "community-terraform-providers/ignition"
+      version = "< 2.0.0"
     }
   }
-  required_version = ">= 0.13"
 }

--- a/modules/cert-refresh-master/versions.tf
+++ b/modules/cert-refresh-master/versions.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 0.13"
   required_providers {
     ignition = {
-      source = "terraform-providers/ignition"
+      source  = "community-terraform-providers/ignition"
+      version = "< 2.0.0"
     }
   }
-  required_version = ">= 0.13"
 }

--- a/modules/cert-refresh-node/versions.tf
+++ b/modules/cert-refresh-node/versions.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 0.13"
   required_providers {
     ignition = {
-      source = "terraform-providers/ignition"
+      source  = "community-terraform-providers/ignition"
+      version = "< 2.0.0"
     }
   }
-  required_version = ">= 0.13"
 }

--- a/modules/systemd_service_restarter/versions.tf
+++ b/modules/systemd_service_restarter/versions.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 0.13"
   required_providers {
     ignition = {
-      source = "terraform-providers/ignition"
+      source  = "community-terraform-providers/ignition"
+      version = "< 2.0.0"
     }
   }
-  required_version = ">= 0.13"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     ignition = {
-      source  = "terraform-providers/ignition"
-      version = ">= 1.2.1"
+      source  = "community-terraform-providers/ignition"
+      version = "< 2.0.0"
     }
     null = {
       source = "hashicorp/null"


### PR DESCRIPTION
The other provider source is deprecated.

Flatcar doesn't support the ignition spec provided by v2.x, hence the constraint.