### PR TITLE
Allow input variables for systemReserved resources

### DIFF
--- a/node-common.tf
+++ b/node-common.tf
@@ -79,8 +79,10 @@ data "template_file" "node-kubelet-conf" {
   template = file("${path.module}/resources/node-kubelet-conf.yaml")
 
   vars = {
-    cluster_dns   = local.cluster_dns_yaml
-    feature_gates = local.feature_gates_yaml_fragment
+    cluster_dns            = local.cluster_dns_yaml
+    feature_gates          = local.feature_gates_yaml_fragment
+    system_reserved_cpu    = var.system_reserved_cpu
+    system_reserved_memory = var.system_reserved_memory
   }
 }
 

--- a/resources/node-kubelet-conf.yaml
+++ b/resources/node-kubelet-conf.yaml
@@ -21,8 +21,8 @@ tlsPrivateKeyFile: "/etc/kubernetes/ssl/kubelet-key.pem"
 # Resource allocation
 cpuManagerPolicy: "static"
 systemReserved:
-  cpu: "1000m"
-  memory: "2Gi"
+  cpu: "${system_reserved_cpu}"
+  memory: "${system_reserved_memory}"
 evictionHard:
   memory.available: "1Gi"
   nodefs.available: "2Gi"

--- a/variables.tf
+++ b/variables.tf
@@ -270,3 +270,13 @@ locals {
   #
   cluster_dns_yaml = join("", formatlist("\n  - \"%s\"", var.cluster_dns))
 }
+
+variable "system_reserved_cpu" {
+  description = "Passed to nodes kubelet config as systemReserved cpu value"
+  default     = "1000m"
+}
+
+variable "system_reserved_memory" {
+  description = "Passed to nodes kubelet config as systemReserved memory value"
+  default     = "2Gi"
+}


### PR DESCRIPTION
We keep the same defaults everywhere, but on exp clusters we run on smaller
nodes and need to allow more room for our system deployments.