### PR TITLE
Remove periodic fstrimmer

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -216,8 +216,6 @@ data "ignition_config" "cfssl" {
       data.ignition_systemd_unit.cfssl.rendered,
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
-      data.ignition_systemd_unit.fstrim_dropin.rendered,
-      data.ignition_systemd_unit.fstrim_timer.rendered,
       data.ignition_systemd_unit.locksmithd_cfssl.rendered,
       data.ignition_systemd_unit.node-exporter.rendered,
       data.ignition_systemd_unit.update-engine.rendered,

--- a/common.tf
+++ b/common.tf
@@ -188,19 +188,6 @@ data "ignition_file" "bashrc" {
   }
 }
 
-data "ignition_systemd_unit" "fstrim_dropin" {
-  name = "fstrim.service"
-
-  dropin {
-    name    = "10-all_mounted_fs.conf"
-    content = file("${path.module}/resources/fstrim.conf")
-  }
-}
-
-data "ignition_systemd_unit" "fstrim_timer" {
-  name = "fstrim.timer"
-}
-
 data "ignition_file" "kubernetes_accounting_config" {
   filesystem = "root"
   path       = "/etc/systemd/system.conf.d/kubernetes-accounting.conf"

--- a/etcd.tf
+++ b/etcd.tf
@@ -218,8 +218,6 @@ data "ignition_config" "etcd" {
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
       data.ignition_systemd_unit.etcd-defrag-timer.rendered,
       data.ignition_systemd_unit.etcd-defrag.rendered,
-      data.ignition_systemd_unit.fstrim_dropin.rendered,
-      data.ignition_systemd_unit.fstrim_timer.rendered,
       data.ignition_systemd_unit.node-exporter.rendered,
       data.ignition_systemd_unit.update-engine.rendered,
       element(data.ignition_systemd_unit.etcd-disk-mounter.*.rendered, count.index),

--- a/master.tf
+++ b/master.tf
@@ -465,8 +465,6 @@ data "ignition_config" "master" {
     [
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
-      data.ignition_systemd_unit.fstrim_dropin.rendered,
-      data.ignition_systemd_unit.fstrim_timer.rendered,
       data.ignition_systemd_unit.locksmithd_master.rendered,
       data.ignition_systemd_unit.master-kubelet.rendered,
       data.ignition_systemd_unit.prepare-crictl.rendered,

--- a/resources/fstrim.conf
+++ b/resources/fstrim.conf
@@ -1,5 +1,0 @@
-[Service]
-# Use `-a` flag - Flatcar does not have /etc/fstab file - so run against all
-# mounted filesystems
-ExecStart=
-ExecStart=/sbin/fstrim -av

--- a/worker.tf
+++ b/worker.tf
@@ -66,8 +66,6 @@ data "ignition_config" "worker" {
     [
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
-      data.ignition_systemd_unit.fstrim_dropin.rendered,
-      data.ignition_systemd_unit.fstrim_timer.rendered,
       data.ignition_systemd_unit.locksmithd_worker.rendered,
       data.ignition_systemd_unit.prepare-crictl.rendered,
       data.ignition_systemd_unit.prometheus-machine-role-worker.rendered,


### PR DESCRIPTION
We are opting for `discard` mount option for on premises/trident pvcs. We should
not need to force a periodic trim action to our nodes.