### PR TITLE
Enable systemd cgroups driver

### DIFF
--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -1,6 +1,5 @@
 # adapted from: https://github.com/kinvolk/coreos-overlay/blob/main/app-emulation/containerd/files/config.toml
 
-# UW: switch to version 2 syntax
 version = 2
 
 # persistent data location
@@ -11,25 +10,30 @@ state = "/run/containerd"
 subreaper = true
 # set containerd's OOM score
 oom_score = -999
-# CRI plugin listens on a TCP port by default
 disabled_plugins = []
 
 # grpc configuration
 [grpc]
-  address = "/run/containerd/containerd.sock"
-  # socket uid
-  uid = 0
-  # socket gid
-  gid = 0
+address = "/run/containerd/containerd.sock"
+# socket uid
+uid = 0
+# socket gid
+gid = 0
 
 [plugins."io.containerd.runtime.v1.linux"]
-  # shim binary name/path
-  shim = "containerd-shim"
-  # runtime binary name/path
-  runtime = "runc"
-  # do not use a shim when starting containers, saves on memory but
-  # live restore is not supported
-  no_shim = false
+# shim binary name/path
+shim = "containerd-shim"
+# runtime binary name/path
+runtime = "runc"
+# do not use a shim when starting containers, saves on memory but
+# live restore is not supported
+no_shim = false
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+# setting runc.options unsets parent settings
+runtime_type = "io.containerd.runc.v2"
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+SystemdCgroup = true
 
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
   endpoint = ["${dockerhub_mirror_endpoint}"]

--- a/resources/master-kubelet-conf.yaml
+++ b/resources/master-kubelet-conf.yaml
@@ -17,3 +17,4 @@ serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"
 tlsCertFile: "/etc/kubernetes/ssl/kubelet.pem"
 tlsPrivateKeyFile: "/etc/kubernetes/ssl/kubelet-key.pem"
+cgroupDriver: systemd

--- a/resources/node-kubelet-conf.yaml
+++ b/resources/node-kubelet-conf.yaml
@@ -17,6 +17,7 @@ serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"
 tlsCertFile: "/etc/kubernetes/ssl/kubelet.pem"
 tlsPrivateKeyFile: "/etc/kubernetes/ssl/kubelet-key.pem"
+cgroupDriver: systemd
 
 # Resource allocation
 cpuManagerPolicy: "static"


### PR DESCRIPTION
* Recommended by kube if running a systemd OS: https://kubernetes.io/docs/setup/production-environment/container-runtimes/
* Flatcar hints that kubernetes and cgroups v2 only works with systemd
  driver
  (https://www.flatcar-linux.org/docs/latest/container-runtimes/switching-to-unified-cgroups/#kubernetes)
  but I haven't found any kubernetes docs backing this claim
* docker is using systemd cgroups automatically after detecting that
  it's running on cgroupsv2. Not sure how having containerd still on
  cgroupfs driver can affect the system
* systemd driver is used in flatcar's upstream containerd overlay
  (https://github.com/kinvolk/coreos-overlay/blob/main/app-emulation/containerd/files/config.toml)