### PR TITLE
Mitigate CVE-2022-0185

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -227,6 +227,7 @@ data "ignition_file" "sysctl_kernel_vars" {
 fs.inotify.max_user_watches=1048576
 fs.inotify.max_user_instances=8192
 vm.max_map_count=262144
+user.max_user_namespaces=0
 EOS
   }
 }


### PR DESCRIPTION
A new CVE made us aware that any unprivileged user of a container can
get full capabilities easily, circumventing our PodSecurityPolicies.

This is fixes the "unshare" escape. More details in the reference blogs
below.

Reference:
* https://blog.aquasec.com/cve-2022-0185-linux-kernel-container-escape-in-kubernetes
* https://sysdig.com/blog/cve-2022-0185-container-escape/