### PR TITLE
Remove fstrim service

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -217,8 +217,6 @@ data "ignition_config" "cfssl" {
       data.ignition_systemd_unit.cfssl.rendered,
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
-      data.ignition_systemd_unit.fstrim_dropin.rendered,
-      data.ignition_systemd_unit.fstrim_timer.rendered,
       data.ignition_systemd_unit.locksmithd_cfssl.rendered,
       data.ignition_systemd_unit.node-exporter.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,

--- a/common.tf
+++ b/common.tf
@@ -198,19 +198,6 @@ data "ignition_file" "bashrc" {
   }
 }
 
-data "ignition_systemd_unit" "fstrim_dropin" {
-  name = "fstrim.service"
-
-  dropin {
-    name    = "10-all_mounted_fs.conf"
-    content = file("${path.module}/resources/fstrim.conf")
-  }
-}
-
-data "ignition_systemd_unit" "fstrim_timer" {
-  name = "fstrim.timer"
-}
-
 data "ignition_file" "kubernetes_accounting_config" {
   filesystem = "root"
   path       = "/etc/systemd/system.conf.d/kubernetes-accounting.conf"

--- a/etcd.tf
+++ b/etcd.tf
@@ -219,8 +219,6 @@ data "ignition_config" "etcd" {
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
       data.ignition_systemd_unit.etcd-defrag-timer.rendered,
       data.ignition_systemd_unit.etcd-defrag.rendered,
-      data.ignition_systemd_unit.fstrim_dropin.rendered,
-      data.ignition_systemd_unit.fstrim_timer.rendered,
       data.ignition_systemd_unit.node-exporter.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_timer.rendered,

--- a/master.tf
+++ b/master.tf
@@ -470,8 +470,6 @@ data "ignition_config" "master" {
     [
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
-      data.ignition_systemd_unit.fstrim_dropin.rendered,
-      data.ignition_systemd_unit.fstrim_timer.rendered,
       data.ignition_systemd_unit.locksmithd_master.rendered,
       data.ignition_systemd_unit.master-kubelet.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,

--- a/resources/fstrim.conf
+++ b/resources/fstrim.conf
@@ -1,5 +1,0 @@
-[Service]
-# Use `-a` flag - Flatcar does not have /etc/fstab file - so run against all
-# mounted filesystems
-ExecStart=
-ExecStart=/sbin/fstrim -av

--- a/worker.tf
+++ b/worker.tf
@@ -67,8 +67,6 @@ data "ignition_config" "worker" {
     [
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
-      data.ignition_systemd_unit.fstrim_dropin.rendered,
-      data.ignition_systemd_unit.fstrim_timer.rendered,
       data.ignition_systemd_unit.locksmithd_worker.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_timer.rendered,


### PR DESCRIPTION
We have now moved nodes in merit to online discard, no need for periodic
fstrim.
