### PR TITLE
Allow setting 1.21 kube version

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -362,7 +362,7 @@ data "template_file" "kube-controller-manager" {
     cloud_config              = var.kube_controller_cloud_config
     pod_network               = var.pod_network
     feature_gates             = local.feature_gates_csv
-    pre_1_22_healthcheck_port = locals.pre_1_22_healthcheck_port
+    pre_1_22_healthcheck_port = local.pre_1_22_healthcheck_port
   }
 }
 

--- a/master.tf
+++ b/master.tf
@@ -357,11 +357,12 @@ data "template_file" "kube-controller-manager" {
   template = file("${path.module}/resources/kube-controller-manager.yaml")
 
   vars = {
-    kubernetes_version = var.kubernetes_version
-    cloud_provider     = var.cloud_provider
-    cloud_config       = var.kube_controller_cloud_config
-    pod_network        = var.pod_network
-    feature_gates      = local.feature_gates_csv
+    kubernetes_version        = var.kubernetes_version
+    cloud_provider            = var.cloud_provider
+    cloud_config              = var.kube_controller_cloud_config
+    pod_network               = var.pod_network
+    feature_gates             = local.feature_gates_csv
+    pre_1_22_healthcheck_port = locals.pre_1_22_healthcheck_port
   }
 }
 

--- a/resources/kube-controller-manager.yaml
+++ b/resources/kube-controller-manager.yaml
@@ -30,8 +30,12 @@ spec:
         httpGet:
           host: 127.0.0.1
           path: /healthz
+%{if pre_1_22_healthcheck_port}
+          port: 10252
+%{else}
           port: 10257
           scheme: HTTPS
+%{endif}
         initialDelaySeconds: 15
         timeoutSeconds: 15
       volumeMounts:

--- a/variables.tf
+++ b/variables.tf
@@ -314,4 +314,7 @@ locals {
   # Kubelet labels
   master_kubelet_labels = join(",", concat(["role=master"], formatlist("%s=%s", keys(var.master_additional_labels), values(var.master_additional_labels))))
   worker_kubelet_labels = join(",", concat(["role=worker"], formatlist("%s=%s", keys(var.worker_additional_labels), values(var.worker_additional_labels))))
+
+  # 1.22 controller-manager healthcheck port
+  pre_1_22_healthcheck_port = split(".", var.kubernetes_version)[1] <= 21
 }


### PR DESCRIPTION
Almost all changes are compatible with v1.21 - apart from
controller-manager healthcheck port.

Using minor version from kubernetes_version var - set a bool if we need
to use the "old" pre 1.22 port or the "new" post 1.22 port.
