### PR TITLE
Default to kube image 1.23.6

### DIFF
--- a/resources/kube-scheduler-config.yaml
+++ b/resources/kube-scheduler-config.yaml
@@ -1,5 +1,5 @@
 kind: KubeSchedulerConfiguration
-apiVersion: kubescheduler.config.k8s.io/v1beta1
+apiVersion: kubescheduler.config.k8s.io/v1beta2
 clientConnection:
   kubeconfig: /etc/kubernetes/config/scheduler.conf
 leaderElection:

--- a/resources/kube-scheduler.yaml
+++ b/resources/kube-scheduler.yaml
@@ -20,8 +20,9 @@ spec:
       livenessProbe:
         httpGet:
           host: 127.0.0.1
+          scheme: HTTPS
           path: /healthz
-          port: 10251
+          port: 10259
         initialDelaySeconds: 15
         timeoutSeconds: 15
       volumeMounts:

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "node_exporter_image_tag" {
 
 variable "kubernetes_version" {
   description = "Kubernetes version, used to specify k8s.gcr.io docker image version and Kubernetes binaries"
-  default     = "v1.22.5"
+  default     = "v1.23.6"
 }
 
 variable "cluster_dns" {


### PR DESCRIPTION
This also requires changes to kube-scheduler due to deprecations and disabling
insecure serving port