### PR TITLE
Raise vm.max_map_count to 393216

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -212,6 +212,8 @@ data "ignition_file" "kubernetes_accounting_config" {
 # https://github.com/giantswarm/k8scloudconfig/blob/master/files/conf/hardening.conf
 # Same approach also mentioned here:
 # https://github.com/kubernetes/kubernetes/issues/64315#issuecomment-904103310
+# vm.max_map_count=393216 adjusted for partner kafkas, which exceeded the
+# previous limit.
 data "ignition_file" "sysctl_kernel_vars" {
   mode       = 420
   filesystem = "root"
@@ -221,7 +223,7 @@ data "ignition_file" "sysctl_kernel_vars" {
     content = <<EOS
 fs.inotify.max_user_watches=1048576
 fs.inotify.max_user_instances=8192
-vm.max_map_count=262144
+vm.max_map_count=393216
 user.max_user_namespaces=0
 EOS
   }

--- a/common.tf
+++ b/common.tf
@@ -212,7 +212,8 @@ data "ignition_file" "kubernetes_accounting_config" {
 # https://github.com/giantswarm/k8scloudconfig/blob/master/files/conf/hardening.conf
 # Same approach also mentioned here:
 # https://github.com/kubernetes/kubernetes/issues/64315#issuecomment-904103310
-# vm.max_map_count=393216 adjusted for partner kafkas, which exceeded the
+#
+# vm.max_map_count=524288 adjusted for partner kafkas, which exceeded the
 # previous limit.
 data "ignition_file" "sysctl_kernel_vars" {
   mode       = 420
@@ -223,7 +224,7 @@ data "ignition_file" "sysctl_kernel_vars" {
     content = <<EOS
 fs.inotify.max_user_watches=1048576
 fs.inotify.max_user_instances=8192
-vm.max_map_count=393216
+vm.max_map_count=524288
 user.max_user_namespaces=0
 EOS
   }


### PR DESCRIPTION
We had an incident in prod-aws where kafka was using a higher number of map
areas (calculated on index files) than our configured 262144 (partner guys
counted 305784 using: `find /opt/kafka/data -name '*index' | wc -l`). This
increases vm.max_map_count to allow enough room for this case.