### PR TITLE
Update terraform-provider-ignition

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -28,7 +28,6 @@ data "template_file" "cfssl-client-config" {
 
 data "ignition_file" "cfssl-client-config" {
   mode       = 384
-  filesystem = "root"
   path       = "/etc/cfssl/config.json"
 
   content {
@@ -56,7 +55,6 @@ data "ignition_systemd_unit" "cfssl-disk-mounter" {
 
 data "ignition_file" "cfssl-ca-csr" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/cfssl/ca-csr.json"
 
   content {
@@ -68,7 +66,6 @@ EOS
 
 data "ignition_file" "cfssl-init-ca" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-init-ca"
 
   content {
@@ -78,7 +75,6 @@ data "ignition_file" "cfssl-init-ca" {
 
 data "ignition_file" "cfssl-init-proxy-pki" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-init-proxy-pki"
 
   content {
@@ -88,7 +84,6 @@ data "ignition_file" "cfssl-init-proxy-pki" {
 
 data "ignition_file" "cfssl-proxy-ca-csr-json" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/cfssl/proxy-ca-csr.json"
 
   content {
@@ -98,7 +93,6 @@ data "ignition_file" "cfssl-proxy-ca-csr-json" {
 
 data "ignition_file" "cfssl-proxy-csr-json" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/cfssl/proxy-csr.json"
 
   content {
@@ -118,7 +112,6 @@ data "template_file" "cfssl-server-config" {
 
 data "ignition_file" "cfssl-server-config" {
   mode       = 384
-  filesystem = "root"
   path       = "/etc/cfssl/config.json"
 
   content {
@@ -133,7 +126,6 @@ data "ignition_systemd_unit" "cfssl" {
 
 data "ignition_file" "cfssl-sk-csr" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/cfssl/sk-csr.json"
 
   content {
@@ -145,7 +137,6 @@ EOS
 
 data "ignition_file" "cfssl-nginx-conf" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/cfssl/sk-nginx.conf"
 
   content {
@@ -155,7 +146,6 @@ data "ignition_file" "cfssl-nginx-conf" {
 
 data "ignition_file" "cfssl-nginx-auth" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/cfssl/sk-nginx.htpasswd"
 
   // it's okay to use PLAIN below since the only thing that this password
@@ -217,11 +207,11 @@ data "ignition_config" "cfssl" {
       data.ignition_systemd_unit.cfssl.rendered,
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
-      data.ignition_systemd_unit.locksmithd_cfssl.rendered,
       data.ignition_systemd_unit.node-exporter.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_timer.rendered,
-      data.ignition_systemd_unit.update-engine.rendered,
+      !var.omit_locksmithd_service ? data.ignition_systemd_unit.locksmithd_cfssl.rendered : "",
+      !var.omit_update_engine_service ? data.ignition_systemd_unit.update-engine.rendered : "",
     ],
     module.cfssl-restarter.systemd_units,
     var.cfssl_additional_systemd_units

--- a/common.tf
+++ b/common.tf
@@ -4,7 +4,6 @@ data "ignition_systemd_unit" "update-engine" {
 }
 
 data "ignition_file" "cfssl" {
-  filesystem = "root"
   path       = "/opt/bin/cfssl"
   mode       = 493
 
@@ -15,7 +14,6 @@ data "ignition_file" "cfssl" {
 }
 
 data "ignition_file" "cfssljson" {
-  filesystem = "root"
   path       = "/opt/bin/cfssljson"
   mode       = 493
 
@@ -59,7 +57,6 @@ data "ignition_systemd_unit" "node-exporter" {
 
 data "ignition_file" "format-and-mount" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/format-and-mount"
 
   content {
@@ -69,7 +66,6 @@ data "ignition_file" "format-and-mount" {
 
 data "ignition_file" "kubelet" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/kubelet"
 
   source {
@@ -79,13 +75,11 @@ data "ignition_file" "kubelet" {
 
 # Dir used by systemd to store logs in disk instead of memory
 data "ignition_directory" "journald" {
-  filesystem = "root"
   path       = "/var/log/journal"
 }
 
 data "ignition_file" "docker_daemon_json" {
   mode       = 493
-  filesystem = "root"
   path       = "/etc/docker/daemon.json"
 
   content {
@@ -99,7 +93,6 @@ data "ignition_file" "docker_daemon_json" {
 
 data "ignition_file" "docker-config" {
   mode       = 384
-  filesystem = "root"
   path       = "/root/.docker/config.json"
 
   content {
@@ -117,7 +110,6 @@ data "ignition_file" "docker-config" {
 
 data "ignition_file" "kubelet-docker-config" {
   mode       = 384
-  filesystem = "root"
   path       = "/var/lib/kubelet/config.json"
 
   content {
@@ -134,7 +126,6 @@ data "ignition_file" "kubelet-docker-config" {
 }
 
 data "ignition_file" "containerd-config" {
-  filesystem = "root"
   path       = "/etc/containerd/config.toml"
   mode       = 384
   content {
@@ -161,7 +152,6 @@ data "ignition_systemd_unit" "containerd-dropin" {
 
 data "ignition_file" "crictl" {
   mode       = 420
-  filesystem = "root"
   path       = "/opt/crictl.tar.gz"
 
   source {
@@ -177,7 +167,6 @@ data "ignition_systemd_unit" "prepare-crictl" {
 }
 
 data "ignition_file" "crictl-config" {
-  filesystem = "root"
   path       = "/etc/crictl.yaml"
   mode       = 384
 
@@ -187,9 +176,9 @@ data "ignition_file" "crictl-config" {
 }
 
 data "ignition_file" "bashrc" {
-  filesystem = "root"
   path       = "/home/core/.bashrc"
   mode       = 420
+  overwrite  = true
   uid        = 500 # core
   gid        = 500 # core
 
@@ -199,7 +188,6 @@ data "ignition_file" "bashrc" {
 }
 
 data "ignition_file" "kubernetes_accounting_config" {
-  filesystem = "root"
   path       = "/etc/systemd/system.conf.d/kubernetes-accounting.conf"
   content {
     content = file("${path.module}/resources/kubernetes-accounting.conf")
@@ -217,7 +205,6 @@ data "ignition_file" "kubernetes_accounting_config" {
 # previous limit.
 data "ignition_file" "sysctl_kernel_vars" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/sysctl.d/kernel.conf"
 
   content {

--- a/etcd.tf
+++ b/etcd.tf
@@ -42,7 +42,6 @@ data "template_file" "etcd-cfssl-new-cert" {
 
 data "ignition_file" "etcd" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/etcd.tar.gz"
 
   source {
@@ -53,7 +52,6 @@ data "ignition_file" "etcd" {
 data "ignition_file" "etcd-cfssl-new-cert" {
   count      = length(var.etcd_addresses)
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-new-cert"
 
   content {
@@ -66,7 +64,6 @@ data "ignition_file" "etcd-cfssl-new-cert" {
 
 data "ignition_file" "etcd-prom-machine-role" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/prom-text-collectors/machine_role.prom"
 
   content {
@@ -88,7 +85,6 @@ data "template_file" "etcdctl-wrapper" {
 data "ignition_file" "etcdctl-wrapper" {
   count      = length(var.etcd_addresses)
   mode       = 493
-  filesystem = "root"
   uid        = 500
   gid        = 500
   path       = "/opt/bin/etcdctl-wrapper"
@@ -178,7 +174,6 @@ data "ignition_file" "etcd-restore" {
   count      = length(var.etcd_addresses)
   path       = "/opt/bin/etcd-restore"
   mode       = 493
-  filesystem = "root"
 
   content {
     content = templatefile("${path.module}/resources/etcd-restore.template", {
@@ -222,10 +217,10 @@ data "ignition_config" "etcd" {
       data.ignition_systemd_unit.node-exporter.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_timer.rendered,
-      data.ignition_systemd_unit.update-engine.rendered,
       element(data.ignition_systemd_unit.etcd-disk-mounter.*.rendered, count.index),
       element(data.ignition_systemd_unit.etcd-member.*.rendered, count.index),
-      element(data.ignition_systemd_unit.locksmithd_etcd.*.rendered, count.index),
+      !var.omit_update_engine_service ? data.ignition_systemd_unit.update-engine.rendered : "",
+      !var.omit_locksmithd_service ? element(data.ignition_systemd_unit.locksmithd_etcd.*.rendered, count.index) : "",
     ],
     module.etcd-cert-fetcher.systemd_units,
     var.etcd_additional_systemd_units

--- a/master.tf
+++ b/master.tf
@@ -33,7 +33,6 @@ data "template_file" "master-node-cfssl-new-cert" {
 
 data "ignition_file" "master-cfssl-new-node-cert" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-new-node-cert"
 
   content {
@@ -61,7 +60,6 @@ data "template_file" "master-kubelet-cfssl-new-cert" {
 
 data "ignition_file" "master-kubelet-cfssl-new-cert" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-new-kubelet-cert"
 
   content {
@@ -102,7 +100,6 @@ data "template_file" "master-apiserver-cfssl-new-cert" {
 
 data "ignition_file" "master-cfssl-new-apiserver-cert" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-new-apiserver-cert"
 
   content {
@@ -130,7 +127,6 @@ data "template_file" "master-apiserver-kubelet-client-cfssl-new-cert" {
 
 data "ignition_file" "master-cfssl-new-apiserver-kubelet-client-cert" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-new-apiserver-kubelet-client-cert"
 
   content {
@@ -158,7 +154,6 @@ data "template_file" "master-scheduler-cfssl-new-cert" {
 
 data "ignition_file" "master-cfssl-new-scheduler-cert" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-new-scheduler-cert"
 
   content {
@@ -186,7 +181,6 @@ data "template_file" "master-controller-manager-cfssl-new-cert" {
 
 data "ignition_file" "master-cfssl-new-controller-manager-cert" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-new-controller-manager-cert"
 
   content {
@@ -205,7 +199,6 @@ data "template_file" "master-cfssl-keys-and-certs-get" {
 
 data "ignition_file" "master-cfssl-keys-and-certs-get" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-keys-and-certs-get"
 
   content {
@@ -243,7 +236,6 @@ data "template_file" "master-kubelet-conf" {
 
 data "ignition_file" "master-kubelet-conf" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/config/master-kubelet-conf.yaml"
 
   content {
@@ -261,7 +253,6 @@ data "template_file" "master-kubeconfig" {
 
 data "ignition_file" "kubelet-kubeconfig" {
   mode       = 420
-  filesystem = "root"
   path       = "/var/lib/kubelet/kubeconfig"
 
   content {
@@ -279,7 +270,6 @@ data "template_file" "scheduler-kubeconfig" {
 
 data "ignition_file" "scheduler-kubeconfig" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/config/scheduler.conf"
 
   content {
@@ -297,7 +287,6 @@ data "template_file" "controller-manager-kubeconfig" {
 
 data "ignition_file" "controller-manager-kubeconfig" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/config/controller-manager.conf"
 
   content {
@@ -331,7 +320,6 @@ data "template_file" "kube-apiserver" {
 
 data "ignition_file" "kube-apiserver" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/manifests/kube-apiserver.yaml"
 
   content {
@@ -345,7 +333,6 @@ data "template_file" "audit-policy" {
 
 data "ignition_file" "audit-policy" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/config/audit-policy.yaml"
 
   content {
@@ -367,7 +354,6 @@ data "template_file" "kube-controller-manager" {
 
 data "ignition_file" "kube-controller-manager" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/manifests/kube-controller-manager.yaml"
 
   content {
@@ -377,7 +363,6 @@ data "ignition_file" "kube-controller-manager" {
 
 data "ignition_file" "kube-controller-conf" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/config/cloud_provider/cloud.conf"
 
   content {
@@ -396,7 +381,6 @@ data "template_file" "kube-scheduler" {
 
 data "ignition_file" "kube-scheduler" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/manifests/kube-scheduler.yaml"
 
   content {
@@ -406,7 +390,6 @@ data "ignition_file" "kube-scheduler" {
 
 data "ignition_file" "kube-scheduler-config" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/config/kube-scheduler-config.yaml"
 
   content {
@@ -416,7 +399,6 @@ data "ignition_file" "kube-scheduler-config" {
 
 data "ignition_file" "master-prom-machine-role" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/prom-text-collectors/machine_role.prom"
 
   content {
@@ -471,12 +453,12 @@ data "ignition_config" "master" {
     [
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
-      data.ignition_systemd_unit.locksmithd_master.rendered,
       data.ignition_systemd_unit.master-kubelet.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_timer.rendered,
       data.ignition_systemd_unit.prepare-crictl.rendered,
-      data.ignition_systemd_unit.update-engine.rendered,
+      !var.omit_locksmithd_service ? data.ignition_systemd_unit.locksmithd_master.rendered : "",
+      !var.omit_update_engine_service ? data.ignition_systemd_unit.update-engine.rendered : "",
     ],
     module.cert-refresh-master.systemd_units,
     var.master_additional_systemd_units,

--- a/modules/cert-fetcher-etcd/versions.tf
+++ b/modules/cert-fetcher-etcd/versions.tf
@@ -3,7 +3,6 @@ terraform {
   required_providers {
     ignition = {
       source  = "community-terraform-providers/ignition"
-      version = "< 2.0.0"
     }
   }
 }

--- a/modules/cert-refresh-master/versions.tf
+++ b/modules/cert-refresh-master/versions.tf
@@ -3,7 +3,6 @@ terraform {
   required_providers {
     ignition = {
       source  = "community-terraform-providers/ignition"
-      version = "< 2.0.0"
     }
   }
 }

--- a/modules/cert-refresh-node/versions.tf
+++ b/modules/cert-refresh-node/versions.tf
@@ -3,7 +3,6 @@ terraform {
   required_providers {
     ignition = {
       source  = "community-terraform-providers/ignition"
-      version = "< 2.0.0"
     }
   }
 }

--- a/modules/systemd_service_restarter/versions.tf
+++ b/modules/systemd_service_restarter/versions.tf
@@ -3,7 +3,6 @@ terraform {
   required_providers {
     ignition = {
       source  = "community-terraform-providers/ignition"
-      version = "< 2.0.0"
     }
   }
 }

--- a/node-common.tf
+++ b/node-common.tf
@@ -18,7 +18,6 @@ data "template_file" "node-cfssl-new-cert" {
 
 data "ignition_file" "node-cfssl-new-cert" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-new-cert"
 
   content {
@@ -46,7 +45,6 @@ data "template_file" "node-kubelet-cfssl-new-cert" {
 
 data "ignition_file" "node-kubelet-cfssl-new-cert" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/cfssl-new-kubelet-cert"
 
   content {
@@ -66,7 +64,6 @@ data "template_file" "node-kubeconfig" {
 
 data "ignition_file" "node-kubeconfig" {
   mode       = 420
-  filesystem = "root"
   path       = "/var/lib/kubelet/kubeconfig"
 
   content {
@@ -90,7 +87,6 @@ data "template_file" "node-kubelet-conf" {
 
 data "ignition_file" "node-kubelet-conf" {
   mode       = 420
-  filesystem = "root"
   path       = "/etc/kubernetes/config/node-kubelet-conf.yaml"
 
   content {
@@ -130,7 +126,6 @@ data "ignition_systemd_unit" "prometheus-ro-rootfs-timer" {
 
 data "ignition_file" "prometheus-ro-rootfs" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/prometheus-ro-rootfs"
 
   content {

--- a/resources/master-kubelet-conf.yaml
+++ b/resources/master-kubelet-conf.yaml
@@ -20,3 +20,7 @@ serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"
 tlsCertFile: "/etc/kubernetes/ssl/kubelet.pem"
 tlsPrivateKeyFile: "/etc/kubernetes/ssl/kubelet-key.pem"
+# Point kubelet to the "real" resolv.conf to avoid loopback addresses that will
+# be detected as a loop via CoreDNS https://coredns.io/plugins/loop/#troubleshooting
+# Flatcar discussion around the issue: https://github.com/flatcar-linux/Flatcar/issues/285
+resolvConf: /run/systemd/resolve/resolv.conf

--- a/resources/node-kubelet-conf.yaml
+++ b/resources/node-kubelet-conf.yaml
@@ -20,6 +20,10 @@ serializeImagePulls: false
 staticPodPath: "/etc/kubernetes/manifests"
 tlsCertFile: "/etc/kubernetes/ssl/kubelet.pem"
 tlsPrivateKeyFile: "/etc/kubernetes/ssl/kubelet-key.pem"
+# Point kubelet to the "real" resolv.conf to avoid loopback addresses that will
+# be detected as a loop via CoreDNS https://coredns.io/plugins/loop/#troubleshooting
+# Flatcar discussion around the issue: https://github.com/flatcar-linux/Flatcar/issues/285
+resolvConf: "/run/systemd/resolve/resolv.conf"
 
 # Resource allocation
 cpuManagerPolicy: "static"

--- a/textfile-collectors.tf
+++ b/textfile-collectors.tf
@@ -11,7 +11,6 @@ data "ignition_systemd_unit" "node_textfile_inode_fd_count_timer" {
 
 data "ignition_file" "node_textfile_inode_fd_count" {
   mode       = 493
-  filesystem = "root"
   path       = "/opt/bin/node_textfile_inode_fd_count"
 
   content {

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,16 @@ variable "enable_container_linux_locksmithd_worker" {
   default     = true
 }
 
+variable "omit_locksmithd_service" {
+  description = "Whether to omit locksmithd service from ignition. It should be used when passing locksmithd service as additional config to avoid ignition failures"
+  default     = false
+}
+
+variable "omit_update_engine_service" {
+  description = "Whether to omit update-engine service from ignition. It should be used when passing update-engine service as additional config to avoid ignition failures"
+  default     = false
+}
+
 variable "containerd_log_level" {
   description = "Log level for the containerd daemon (debug, info, warn, error, fatal, panic)"
   default     = "warn"

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,6 @@ terraform {
   required_providers {
     ignition = {
       source  = "community-terraform-providers/ignition"
-      version = "< 2.0.0"
     }
     null = {
       source = "hashicorp/null"

--- a/worker.tf
+++ b/worker.tf
@@ -67,7 +67,6 @@ data "ignition_config" "worker" {
     [
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
-      data.ignition_systemd_unit.locksmithd_worker.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_timer.rendered,
       data.ignition_systemd_unit.prepare-crictl.rendered,
@@ -75,8 +74,9 @@ data "ignition_config" "worker" {
       data.ignition_systemd_unit.prometheus-ro-rootfs-timer.rendered,
       data.ignition_systemd_unit.prometheus-ro-rootfs.rendered,
       data.ignition_systemd_unit.prometheus-tmpfs-dir.rendered,
-      data.ignition_systemd_unit.update-engine.rendered,
       data.ignition_systemd_unit.worker-kubelet.rendered,
+      !var.omit_locksmithd_service ? data.ignition_systemd_unit.locksmithd_worker.rendered : "",
+      !var.omit_update_engine_service ? data.ignition_systemd_unit.update-engine.rendered : "",
     ],
     module.cert-refresh-node.systemd_units,
     var.worker_additional_systemd_units


### PR DESCRIPTION
- Do not pin ignition terraform provider to < 2.0.0
- Use variable to omit locksmithd and update-engine. For on-prem clusters we
  pass these systemd units as they are generated via flatcar-pxe-update-engine
  and ignition 2.13.0 fails due to duplicate units.
- Support format for latest ignition.