### PR TITLE
Upgrade ETCD and NGINX

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "etcd_image_url" {
 
 variable "etcd_image_tag" {
   description = "The version of the etcd image to use."
-  default     = "v3.5.0"
+  default     = "v3.5.4"
 }
 
 variable "etcd_data_dir" {
@@ -232,14 +232,14 @@ variable "dockerhub_password" {
   description = "Docker Hub password"
 }
 
+variable "nginx_image" {
+  description = "https://github.com/nginx/nginx/releases"
+  default     = "nginx:1.23-alpine"
+}
+
 variable "crictl_version" {
   description = "The version of the crictl release to install"
   default     = "v1.19.0"
-}
-
-variable "nginx_image" {
-  description = "https://github.com/nginx/nginx/releases"
-  default     = "nginx:1.21-alpine"
 }
 
 variable "crictl_verification" {


### PR DESCRIPTION
Running ETCD 3.5.0 in production is no longer recommended because of
data corruption issue:
https://github.com/etcd-io/etcd/tree/main/CHANGELOG#v35-data-corruption-issue

Upgrading to 3.5.4 as recommended which fixes this issue.

Also upgrade NGINX to latest available.
