### PR TITLE
Split etcd locksmithd dropin config into separate file

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,11 @@ variable "omit_locksmithd_service" {
   default     = false
 }
 
+variable "set_etcd_locksmithd_dropin_reboot_config" {
+  description = "Whether to create a dropin to configure etcd locksmithd reboot windows"
+  default     = true
+}
+
 variable "omit_update_engine_service" {
   description = "Whether to omit update-engine service from ignition. It should be used when passing update-engine service as additional config to avoid ignition failures"
   default     = false


### PR DESCRIPTION
Create an ignition file for etcds locksmithd droping configuration. This can be useful in cases where we pass a custom locksmithd service via `etcd_additional_systemd_units` variable, but still need to configure the reboot windows for instances, like we do in merit clusters.