### PR TITLE
Force reprovisioning of master and worker nodes on reboot

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -196,9 +196,9 @@ EOS
   }
 }
 
-# `touch` /boot/flatcar/first_boot to trigger ignition to run every time
+# `touch` /boot/flatcar/first_boot to trigger ignition to run every time:
 # https://flatcar-linux.org/docs/latest/provisioning/ignition/boot-process/#reprovisioning
-# Can be useful for case where we want reprovisioning after every boot
+# Useful when we want to fetch ignition updates during boot.
 data "ignition_systemd_unit" "flatcar_first_boot" {
   name    = "ensure-flatcar-first-boot.service"
   content = <<EOS
@@ -217,8 +217,9 @@ EOS
 }
 
 # Specifies a root filesystem where we wipe the device before filesystem
-# creation. Could be useful when reprovisioning ignition on the same node.
-data "ignition_filesystem" "wiped_root" {
+# creation. When combined with ignition reprovisioning it can give us "fresh"
+# nodes on reboot.
+data "ignition_filesystem" "root_wipe_filesystem" {
   device          = "/dev/disk/by-partlabel/ROOT"
   format          = "ext4"
   wipe_filesystem = true

--- a/master.tf
+++ b/master.tf
@@ -407,6 +407,10 @@ locals {
 }
 
 data "ignition_config" "master" {
+  filesystems = [
+    var.force_boot_reprovisioning ? data.ignition_filesystem.wiped_root.rendered : "",
+  ]
+
   files = concat(
     [
       data.ignition_file.audit-policy.rendered,
@@ -453,6 +457,7 @@ data "ignition_config" "master" {
       data.ignition_systemd_unit.node_textfile_inode_fd_count_timer.rendered,
       !var.omit_locksmithd_service ? data.ignition_systemd_unit.locksmithd_master.rendered : "",
       !var.omit_update_engine_service ? data.ignition_systemd_unit.update-engine.rendered : "",
+      var.force_boot_reprovisioning ? data.ignition_systemd_unit.flatcar_first_boot.rendered : "",
     ],
     module.cert-refresh-master.systemd_units,
     var.master_additional_systemd_units,

--- a/master.tf
+++ b/master.tf
@@ -418,7 +418,7 @@ locals {
 
 data "ignition_config" "master" {
   filesystems = [
-    var.force_boot_reprovisioning ? data.ignition_filesystem.wiped_root.rendered : "",
+    var.force_boot_reprovisioning ? data.ignition_filesystem.root_wipe_filesystem.rendered : "",
   ]
 
   files = concat(

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,11 @@ variable "enable_container_linux_locksmithd_worker" {
   default     = true
 }
 
+variable "force_boot_reprovisioning" {
+  description = "Force a new Ignition run on every reboot and wipe root filesystem"
+  default     = false
+}
+
 variable "omit_locksmithd_service" {
   description = "Whether to omit locksmithd service from ignition. It should be used when passing locksmithd service as additional config to avoid ignition failures"
   default     = false

--- a/worker.tf
+++ b/worker.tf
@@ -45,7 +45,7 @@ data "ignition_systemd_unit" "prometheus-eviction-threshold-worker" {
 // data.ignition_file.worker-prom-machine-role.rendered,
 data "ignition_config" "worker" {
   filesystems = [
-    var.force_boot_reprovisioning ? data.ignition_filesystem.wiped_root.rendered : "",
+    var.force_boot_reprovisioning ? data.ignition_filesystem.root_wipe_filesystem.rendered : "",
   ]
 
   files = concat(

--- a/worker.tf
+++ b/worker.tf
@@ -37,6 +37,10 @@ data "ignition_systemd_unit" "prometheus-machine-role-worker" {
 
 // data.ignition_file.worker-prom-machine-role.rendered,
 data "ignition_config" "worker" {
+  filesystems = [
+    var.force_boot_reprovisioning ? data.ignition_filesystem.wiped_root.rendered : "",
+  ]
+
   files = concat(
     [
       data.ignition_file.bashrc.rendered,
@@ -74,6 +78,7 @@ data "ignition_config" "worker" {
       data.ignition_systemd_unit.worker-kubelet.rendered,
       !var.omit_locksmithd_service ? data.ignition_systemd_unit.locksmithd_worker.rendered : "",
       !var.omit_update_engine_service ? data.ignition_systemd_unit.update-engine.rendered : "",
+      var.force_boot_reprovisioning ? data.ignition_systemd_unit.flatcar_first_boot.rendered : "",
     ],
     module.cert-refresh-node.systemd_units,
     var.worker_additional_systemd_units


### PR DESCRIPTION
This is optionally setting a service that touches `/boot/flatcar/first_boot` to trigger rerunning ignition on boot. It also wipes root volume via ignition config to start fresh.
https://flatcar-linux.org/docs/latest/provisioning/ignition/boot-process/#reprovisioning