### PR TITLE
Enable TopologyAwareHints by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -265,7 +265,9 @@ variable "feature_gates" {
   #   "PodShareProcessNamespace"  = "true"
   # }
   # ```
-  default = {}
+  default = {
+    "TopologyAwareHints" : "true"
+  }
 }
 
 variable "admission_plugins" {


### PR DESCRIPTION
We can remove the feature_gate override from module consumers, they all use the
same value.
