### PR TITLE
Enable leader migration for kube controller manager

### DIFF
--- a/resources/kube-controller-manager.yaml
+++ b/resources/kube-controller-manager.yaml
@@ -19,6 +19,7 @@ spec:
         - --authorization-kubeconfig=/etc/kubernetes/config/controller-manager.conf
         - --cluster-cidr=${pod_network}
         - --configure-cloud-routes=false
+        - --enable-leader-migration=true
         - --kubeconfig=/etc/kubernetes/config/controller-manager.conf
         - --leader-elect=true
         - --node-monitor-grace-period=120s

--- a/variables.tf
+++ b/variables.tf
@@ -168,7 +168,9 @@ variable "master_additional_files" {
 variable "master_additional_labels" {
   description = "Map of additional labels to append to role=master in the respective master nodes kubelet flag."
   type        = map(string)
-  default     = {}
+  default     = {
+    kube-controller-manager-mode = "enable-leader-migration" # temporary workaround to help scheduling controllers
+  }
 }
 
 


### PR DESCRIPTION
Needed prior to switching to external cloud-controller-manager