### PR TITLE
Use v2 aws metadata endpoint

### DIFF
--- a/_data.tf
+++ b/_data.tf
@@ -3,7 +3,7 @@ variable "node_name_command" {
 
   default = {
     ""    = "hostname -f"
-    "aws" = "curl -s http://169.254.169.254/latest/meta-data/local-hostname"
+    "aws" = "/opt/bin/aws-imdsv2 local-hostname"
     "gce" = "curl -s http://metadata.google.internal/computeMetadata/v1/instance/hostname -H Metadata-Flavor:Google"
   }
 }
@@ -13,7 +13,7 @@ variable "get_ip_command" {
 
   default = {
     ""    = "ip route get 1.2.3.4 | head  -n 1 | awk '{print $7}'"
-    "aws" = "curl -s http://169.254.169.254/latest/meta-data/local-ipv4"
+    "aws" = "/opt/bin/aws-imdsv2 local-ipv4"
     "gce" = "curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip -H Metadata-Flavor:Google"
   }
 }

--- a/cfssl.tf
+++ b/cfssl.tf
@@ -188,6 +188,7 @@ data "ignition_file" "cfssl-prom-machine-role" {
 data "ignition_config" "cfssl" {
   files = concat(
     [
+      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
       data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl-ca-csr.rendered,
       data.ignition_file.cfssl-init-ca.rendered,

--- a/common.tf
+++ b/common.tf
@@ -225,3 +225,17 @@ data "ignition_filesystem" "root_wipe_filesystem" {
   wipe_filesystem = true
   label           = "ROOT"
 }
+
+data "ignition_file" "aws_meta_data_IMDSv2" {
+  mode = 493
+  path = "/opt/bin/aws-imdsv2"
+
+  content {
+    content = <<EOS
+#!/bin/sh
+META_ENDPOINT=$1
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 600")
+curl http://169.254.169.254/latest/meta-data/$META_ENDPOINT -H "X-aws-ec2-metadata-token: $TOKEN"
+EOS
+  }
+}

--- a/etcd.tf
+++ b/etcd.tf
@@ -199,6 +199,7 @@ data "ignition_config" "etcd" {
 
   files = concat(
     [
+      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
       data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl-client-config.rendered,
       data.ignition_file.cfssl.rendered,

--- a/master.tf
+++ b/master.tf
@@ -423,6 +423,7 @@ data "ignition_config" "master" {
 
   files = concat(
     [
+      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
       data.ignition_file.audit-policy.rendered,
       data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl-client-config.rendered,

--- a/worker.tf
+++ b/worker.tf
@@ -50,6 +50,7 @@ data "ignition_config" "worker" {
 
   files = concat(
     [
+      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
       data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl-client-config.rendered,
       data.ignition_file.cfssl.rendered,


### PR DESCRIPTION
Recommended as best practice:
https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/