### PR TITLE
Remove TORCX references, it has been removed from Flatcar

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -128,7 +128,6 @@ data "ignition_file" "containerd-config" {
     content = templatefile("${path.module}/resources/containerd-config.toml",
       {
         containerd_log_level      = var.containerd_log_level
-        containerd_no_shim        = tostring(var.containerd_no_shim)
         dockerhub_auth            = base64encode("${var.dockerhub_username}:${var.dockerhub_password}"),
         dockerhub_mirror_endpoint = var.dockerhub_mirror_endpoint,
       }

--- a/resources/containerd-config.toml
+++ b/resources/containerd-config.toml
@@ -1,4 +1,4 @@
-# adapted from: https://github.com/kinvolk/coreos-overlay/blob/main/app-emulation/containerd/files/config.toml
+# adapted from: /usr/share/containerd/config.toml on disk
 version = 2
 
 # persistent data location
@@ -26,7 +26,7 @@ shim = "containerd-shim"
 runtime = "runc"
 # do not use a shim when starting containers, saves on memory but
 # live restore is not supported
-no_shim = ${containerd_no_shim}
+no_shim = false
 
 [plugins."io.containerd.grpc.v1.cri"]
 # enable SELinux labeling

--- a/resources/containerd-dropin.conf
+++ b/resources/containerd-dropin.conf
@@ -1,4 +1,3 @@
 [Service]
-Environment=CONTAINERD_CONFIG=/etc/containerd/config.toml
 ExecStart=
-ExecStart=/usr/bin/env PATH=${TORCX_BINDIR}:${PATH} ${TORCX_BINDIR}/containerd --config ${CONTAINERD_CONFIG}
+ExecStart=/usr/bin/containerd

--- a/variables.tf
+++ b/variables.tf
@@ -298,12 +298,6 @@ variable "eviction_threshold_memory_hard" {
   default     = "1073741824" # 1Gi(2^30 bytes)
 }
 
-variable "containerd_no_shim" {
-  description = "Do not user containerd shim, only used for live restore which we don't use"
-  default     = false
-  type        = bool
-}
-
 locals {
   component_cloud_provider = can(regex("aws|gce", var.cloud_provider)) ? "external" : var.cloud_provider
 


### PR DESCRIPTION
Also remove containerd_no_shim flag, its now set to "false" and I don't
think we have usecase to modify it.
