### PR TITLE
Allow overriding kubelet node-labels via dropin

### DIFF
--- a/resources/master-kubelet.service
+++ b/resources/master-kubelet.service
@@ -4,6 +4,7 @@ Requires=containerd.service
 After=containerd.service
 [Service]
 EnvironmentFile=-/etc/kubernetes/config/kubeletenv
+Environmnet=KUBE_NODE_LABELS=${labels}
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/config
 ExecStartPre=/usr/bin/truncate -s0 /etc/kubernetes/config/kubeletenv
 ExecStartPre=/bin/sh -c 'echo "NODE_HOSTNAME=$(${get_hostname})" >> /etc/kubernetes/config/kubeletenv'
@@ -23,7 +24,7 @@ ExecStart=${kubelet_binary_path} \
   --hostname-override="$${NODE_HOSTNAME}" \
   --kubeconfig=/var/lib/kubelet/kubeconfig \
   --lock-file=/var/run/lock/kubelet.lock \
-  --node-labels=${labels} \
+  --node-labels="$${KUBE_NODE_LABELS}" \
   --v=0
 Restart=always
 RestartSec=10

--- a/resources/node-kubelet.service
+++ b/resources/node-kubelet.service
@@ -4,6 +4,7 @@ Requires=containerd.service
 After=containerd.service
 [Service]
 EnvironmentFile=-/etc/kubernetes/config/kubeletenv
+Environmnet=KUBE_NODE_LABELS=${labels}
 ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/config
 ExecStartPre=/usr/bin/truncate -s0 /etc/kubernetes/config/kubeletenv
 ExecStartPre=/bin/sh -c 'echo "NODE_HOSTNAME=$(${get_hostname})" >> /etc/kubernetes/config/kubeletenv'
@@ -23,7 +24,7 @@ ExecStart=${kubelet_binary_path} \
   --hostname-override="$${NODE_HOSTNAME}" \
   --kubeconfig=/var/lib/kubelet/kubeconfig \
   --lock-file=/var/run/lock/kubelet.lock \
-  --node-labels=${labels} \
+  --node-labels="$${KUBE_NODE_LABELS}" \
   --v=0
 Restart=always
 RestartSec=10


### PR DESCRIPTION
Even though we offer the ability to supply a label into ignition, this moves the logic to an environment variable to be able to overwrite with a dropin in case we need further control of those labels per instance subgroup.