### PR TITLE
Update audit-policy to exclude cloud-controller-manager calls

### DIFF
--- a/resources/audit-policy.yaml
+++ b/resources/audit-policy.yaml
@@ -38,6 +38,7 @@ rules:
   - level: None
     users:
       - system:kube-controller-manager
+      - system:cloud-controller-manager
       - system:kube-scheduler
       - system:serviceaccount:kube-system:endpoint-controller
     verbs: ["get", "update"]
@@ -62,6 +63,7 @@ rules:
   - level: None
     users:
       - system:kube-controller-manager
+      - system:cloud-controller-manager
     verbs: ["get", "list"]
     resources:
       - group: "metrics.k8s.io"


### PR DESCRIPTION
With this we are updated with upstream