### PR TITLE
Add option to mask coreos metadata sshkeys service

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -253,3 +253,8 @@ curl http://169.254.169.254/latest/meta-data/$META_ENDPOINT -H "X-aws-ec2-metada
 EOS
   }
 }
+
+data "ignition_systemd_unit" "coreos_metadata_sshkeys" {
+  name = "coreos-metadata-sshkeys@core.service"
+  mask = false == var.enable_coreos_metadata_sshkeys_service
+}

--- a/master.tf
+++ b/master.tf
@@ -483,6 +483,7 @@ data "ignition_config" "master" {
     [
       data.ignition_systemd_unit.containerd-dropin.rendered,
       data.ignition_systemd_unit.control_plane_labeller.rendered,
+      data.ignition_systemd_unit.coreos_metadata_sshkeys.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
       data.ignition_systemd_unit.master-kubelet.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,11 @@ variable "enable_container_linux_locksmithd_worker" {
   default     = true
 }
 
+variable "enable_coreos_metadata_sshkeys_service" {
+  description = "Whether to enable the coreos-metadata-sshkeys@core.service"
+  default     = false
+}
+
 variable "force_boot_reprovisioning" {
   description = "Force a new Ignition run on every reboot and wipe root filesystem"
   default     = false

--- a/worker.tf
+++ b/worker.tf
@@ -76,6 +76,7 @@ data "ignition_config" "worker" {
   systemd = concat(
     [
       data.ignition_systemd_unit.containerd-dropin.rendered,
+      data.ignition_systemd_unit.coreos_metadata_sshkeys.rendered,
       data.ignition_systemd_unit.docker-opts-dropin.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_service.rendered,
       data.ignition_systemd_unit.node_textfile_inode_fd_count_timer.rendered,


### PR DESCRIPTION
Masking `coreos-metadata-sshkeys@core.service` on `master` and `worker`
nodes to avoid flooding logs with:
```
Error: failed to update authorized keys
Caused by: update-ssh-keys: no keys found in "/home/core/.ssh/authorized_keys.d"
coreos-metadata-sshkeys@core.service: Control process exited, code=exited, status=1/FAILURE
coreos-metadata-sshkeys@core.service: Failed with result 'exit-code'.
```
