### PR TITLE
Enable swap on all our Nodes

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -188,7 +188,6 @@ data "ignition_file" "cfssl-prom-machine-role" {
 data "ignition_config" "cfssl" {
   files = concat(
     [
-      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
       data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl-ca-csr.rendered,
       data.ignition_file.cfssl-init-ca.rendered,
@@ -208,6 +207,8 @@ data "ignition_config" "cfssl" {
       data.ignition_file.format-and-mount.rendered,
       data.ignition_file.node_textfile_inode_fd_count.rendered,
       data.ignition_file.sysctl_kernel_vars.rendered,
+      data.ignition_file.zram_generator_conf.rendered,
+      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
     ],
     var.cfssl_additional_files
   )

--- a/common.tf
+++ b/common.tf
@@ -185,6 +185,19 @@ data "ignition_file" "kubernetes_accounting_config" {
   }
 }
 
+# Use the values from "zram-generator-defaults"
+data "ignition_file" "zram_generator_conf" {
+  mode = 420
+  path = "/etc/systemd/zram-generator.conf"
+
+  content {
+    content = <<EOF
+[zram0]
+zram-size = min(ram, 8192)
+EOF
+  }
+}
+
 # Updating to flatcar 2983.2.0 surfaced an issue where inotify resources are
 # exhausted on worker nodes. Increasing inotify watchers and instances was
 # tested to mitigate this issue. Using values from:

--- a/etcd.tf
+++ b/etcd.tf
@@ -199,7 +199,6 @@ data "ignition_config" "etcd" {
 
   files = concat(
     [
-      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
       data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl-client-config.rendered,
       data.ignition_file.cfssl.rendered,
@@ -212,9 +211,11 @@ data "ignition_config" "etcd" {
       data.ignition_file.format-and-mount.rendered,
       data.ignition_file.node_textfile_inode_fd_count.rendered,
       data.ignition_file.sysctl_kernel_vars.rendered,
+      data.ignition_file.zram_generator_conf.rendered,
       element(data.ignition_file.etcd-cfssl-new-cert.*.rendered, count.index),
       element(data.ignition_file.etcd-restore.*.rendered, count.index),
       element(data.ignition_file.etcdctl-wrapper.*.rendered, count.index),
+      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
       var.set_etcd_locksmithd_dropin_reboot_config ? element(data.ignition_file.locksmithd_etcd_dropin.*.rendered, count.index) : "",
     ],
     var.etcd_additional_files

--- a/master.tf
+++ b/master.tf
@@ -440,7 +440,6 @@ data "ignition_config" "master" {
 
   files = concat(
     [
-      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
       data.ignition_file.audit-policy.rendered,
       data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl-client-config.rendered,
@@ -474,6 +473,8 @@ data "ignition_config" "master" {
       data.ignition_file.node_textfile_inode_fd_count.rendered,
       data.ignition_file.scheduler-kubeconfig.rendered,
       data.ignition_file.sysctl_kernel_vars.rendered,
+      data.ignition_file.zram_generator_conf.rendered,
+      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
     ],
     var.master_additional_files,
     [local.kube_controller_additional_config]

--- a/resources/master-kubelet-conf.yaml
+++ b/resources/master-kubelet-conf.yaml
@@ -29,3 +29,7 @@ tlsPrivateKeyFile: "/etc/kubernetes/ssl/kubelet-key.pem"
 # be detected as a loop via CoreDNS https://coredns.io/plugins/loop/#troubleshooting
 # Flatcar discussion around the issue: https://github.com/flatcar-linux/Flatcar/issues/285
 resolvConf: "/run/systemd/resolve/resolv.conf"
+# https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-MemorySwapConfiguration
+failSwapOn: false
+memorySwap:
+  swapBehavior: LimitedSwap

--- a/resources/node-kubelet-conf.yaml
+++ b/resources/node-kubelet-conf.yaml
@@ -57,3 +57,7 @@ evictionSoftGracePeriod:
   memory.available: "1m"
   nodefs.available: "1m"
 evictionMaxPodGracePeriod: 30
+# https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-MemorySwapConfiguration
+failSwapOn: false
+memorySwap:
+  swapBehavior: LimitedSwap

--- a/worker.tf
+++ b/worker.tf
@@ -50,7 +50,6 @@ data "ignition_config" "worker" {
 
   files = concat(
     [
-      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
       data.ignition_file.bashrc.rendered,
       data.ignition_file.cfssl-client-config.rendered,
       data.ignition_file.cfssl.rendered,
@@ -69,6 +68,8 @@ data "ignition_config" "worker" {
       data.ignition_file.node-kubelet-conf.rendered,
       data.ignition_file.node_textfile_inode_fd_count.rendered,
       data.ignition_file.sysctl_kernel_vars.rendered,
+      data.ignition_file.zram_generator_conf.rendered,
+      var.cloud_provider == "aws" ? data.ignition_file.aws_meta_data_IMDSv2.rendered : "",
     ],
     var.worker_additional_files
   )


### PR DESCRIPTION
This enables swap on cfssl/etcd/master/worker nodes.

This will help where instances are running fine, but are utilising
almost all of their memory. This means we cannot use memory pressure
alerts.

This should in theory make Nodes more stable when they are running with
low memory, either allowing us time to drain them or allowing system
oomd to act.
