### PR TITLE
Update kubernetes download link

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -65,7 +65,7 @@ data "ignition_file" "kubelet" {
   path = "/opt/bin/kubelet"
 
   source {
-    source = "https://storage.googleapis.com/kubernetes-release/release/${var.kubernetes_version}/bin/linux/amd64/kubelet"
+    source = "https://dl.k8s.io/${var.kubernetes_version}/bin/linux/amd64/kubelet"
   }
 }
 


### PR DESCRIPTION
The gcp bucket doesn't seem to get updated anymore. Switching to the new
link recommended in https://kubernetes.io/releases/download/
