### PR TITLE
Create a var for control plane cpu limits

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -294,16 +294,17 @@ data "template_file" "kube-apiserver" {
   template = file("${path.module}/resources/kube-apiserver.yaml")
 
   vars = {
-    kubernetes_version    = var.kubernetes_version
-    etcd_endpoints        = join(",", formatlist("https://%s:2379", var.etcd_addresses))
-    service_network       = var.service_network
-    master_address        = var.external_apiserver_address == "" ? var.master_address : var.external_apiserver_address
-    master_instance_count = var.master_instance_count
-    oidc_issuer_url       = var.oidc_issuer_url
-    oidc_client_id        = var.oidc_client_id
-    feature_gates         = local.feature_gates_csv
-    admission_plugins     = var.admission_plugins
-    runtime_config        = join(",", var.apiserver_runtime_config)
+    kubernetes_version           = var.kubernetes_version
+    etcd_endpoints               = join(",", formatlist("https://%s:2379", var.etcd_addresses))
+    service_network              = var.service_network
+    master_address               = var.external_apiserver_address == "" ? var.master_address : var.external_apiserver_address
+    master_instance_count        = var.master_instance_count
+    oidc_issuer_url              = var.oidc_issuer_url
+    oidc_client_id               = var.oidc_client_id
+    feature_gates                = local.feature_gates_csv
+    admission_plugins            = var.admission_plugins
+    runtime_config               = join(",", var.apiserver_runtime_config)
+    control_plane_pod_cpu_limits = var.control_plane_pod_cpu_limits
   }
   /*
      * for the list of APIs & resources enabled by default, please see near the
@@ -339,10 +340,11 @@ data "template_file" "kube-controller-manager" {
   template = file("${path.module}/resources/kube-controller-manager.yaml")
 
   vars = {
-    kubernetes_version = var.kubernetes_version
-    cloud_config       = var.kube_controller_cloud_config
-    pod_network        = var.pod_network
-    feature_gates      = local.feature_gates_csv
+    kubernetes_version           = var.kubernetes_version
+    cloud_config                 = var.kube_controller_cloud_config
+    pod_network                  = var.pod_network
+    feature_gates                = local.feature_gates_csv
+    control_plane_pod_cpu_limits = var.control_plane_pod_cpu_limits
   }
 }
 
@@ -368,8 +370,9 @@ data "template_file" "kube-scheduler" {
   template = file("${path.module}/resources/kube-scheduler.yaml")
 
   vars = {
-    kubernetes_version = var.kubernetes_version
-    feature_gates      = local.feature_gates_csv
+    kubernetes_version           = var.kubernetes_version
+    feature_gates                = local.feature_gates_csv
+    control_plane_pod_cpu_limits = var.control_plane_pod_cpu_limits
   }
 }
 

--- a/resources/kube-apiserver.yaml
+++ b/resources/kube-apiserver.yaml
@@ -77,7 +77,7 @@ spec:
       # https://github.com/kubernetes/kubernetes/issues/129880
       resources:
         limits:
-          cpu: "7"
+          cpu: "${control_plane_pod_cpu_limits}"
           memory: "20Gi"
         requests:
           cpu: "0"

--- a/resources/kube-controller-manager.yaml
+++ b/resources/kube-controller-manager.yaml
@@ -36,7 +36,7 @@ spec:
       # https://github.com/kubernetes/kubernetes/issues/129880
       resources:
         limits:
-          cpu: "7"
+          cpu: "${control_plane_pod_cpu_limits}"
           memory: "8Gi"
         requests:
           cpu: "0"

--- a/resources/kube-scheduler.yaml
+++ b/resources/kube-scheduler.yaml
@@ -28,7 +28,7 @@ spec:
       # https://github.com/kubernetes/kubernetes/issues/129880
       resources:
         limits:
-          cpu: "7"
+          cpu: "${control_plane_pod_cpu_limits}"
           memory: "4Gi"
         requests:
           cpu: "0"

--- a/variables.tf
+++ b/variables.tf
@@ -294,6 +294,11 @@ variable "system_reserved_memory" {
   default     = "2Gi"
 }
 
+variable "control_plane_pod_cpu_limits" {
+  description = "Set the cpu limits for the control plane static pods (kube-apiserver, kube-scheduler, etc.)"
+  default     = "6"
+}
+
 variable "eviction_threshold_memory_soft" {
   description = "Amount of available memory that triggers soft eviction. In bytes to facilitate exporting it as metric"
   default     = "2147483648" # 2Gi(2^31 bytes)


### PR DESCRIPTION
AWS nodes do not allow setting the cpu limits as high as 7. The var will
let us set the most suitable cpu limits value for each environment.