### PR TITLE
Remove deprecated cloud provider flag

### DIFF
--- a/resources/kube-controller-manager.yaml
+++ b/resources/kube-controller-manager.yaml
@@ -11,7 +11,6 @@ spec:
       image: registry.k8s.io/kube-controller-manager:${kubernetes_version}
       command:
         - kube-controller-manager
-        ${cloud_config == "" ? "" : "- --cloud-config=/etc/kubernetes/config/cloud_provider/cloud.conf"}
         ${feature_gates == "" ? "" : "- --feature-gates=${feature_gates}"}
         - --allocate-node-cidrs=true
         - --authentication-kubeconfig=/etc/kubernetes/config/controller-manager.conf

--- a/variables.tf
+++ b/variables.tf
@@ -106,11 +106,6 @@ variable "cloud_provider" {
   default     = ""
 }
 
-variable "kube_controller_cloud_config" {
-  description = "Cloud config to be passed to kube-controller manager (expected as raw text). Nothing will be passed on empty variable"
-  default     = ""
-}
-
 variable "master_instance_count" {
   description = "The number of master instances in the kubernetes cluster. Used by the API server."
   default     = 3


### PR DESCRIPTION
Will be removed in Kubernetes v1.34 -
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#no-really-you-must-read-this-before-you-upgrade
