### PR TITLE
Use specific etcdctl version

### DIFF
--- a/resources/etcd-member.service
+++ b/resources/etcd-member.service
@@ -43,6 +43,13 @@ ExecStartPre=-+/bin/sh -c "\
   chown etcd:etcd /opt/bin/etcd"
 
 ExecStartPre=-+/bin/sh -c "\
+  test ! -f /opt/bin/etcdctl && \
+  test -f /opt/bin/etcd.tar.gz && \
+  tar --strip-components=1 -C /opt/bin \
+    -xzf /opt/bin/etcd.tar.gz etcd-${etcd_version}-linux-amd64/etcdctl && \
+  chown etcd:etcd /opt/bin/etcdctl"
+
+ExecStartPre=-+/bin/sh -c "\
   test ! -f /opt/bin/etcdutl && \
   test -f /opt/bin/etcd.tar.gz && \
   tar --strip-components=1 -C /opt/bin \

--- a/resources/etcdctl-wrapper
+++ b/resources/etcdctl-wrapper
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-exec sudo -u etcd etcdctl \
+exec sudo -u etcd /opt/bin/etcdctl \
   --cacert /etc/etcd/ssl/ca.pem \
   --cert /etc/etcd/ssl/node.pem \
   --key /etc/etcd/ssl/node-key.pem \


### PR DESCRIPTION
Use the same version for etcdctl as we do for etcd and etcdutl, instead of relying on the OS version