### PR TITLE
Extend the CA and Node certificates

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -75,7 +75,9 @@ data "ignition_file" "cfssl-proxy-ca-csr-json" {
   path = "/etc/cfssl/proxy-ca-csr.json"
 
   content {
-    content = file("${path.module}/resources/cfssl-proxy-ca-csr.json")
+    content = templatefile("${path.module}/resources/cfssl-proxy-ca-csr.json", {
+      ca_expiry_hours = var.cfssl_ca_expiry_hours
+    })
   }
 }
 

--- a/resources/cfssl-init-ca.sh
+++ b/resources/cfssl-init-ca.sh
@@ -10,7 +10,7 @@ fi
 [ -f ca-key.pem ] && _args="-ca-key=ca-key.pem ${_args}"
 
 [ -f ca-key.pem ] && [ -f ca.pem ] \
-    && (( "$(date +%s)" < "$(date -d "$(/opt/bin/cfssl certinfo -cert=/var/lib/cfssl/ca.pem | jq -r '.not_after')" +%s)" - 7 * 24 * 3600 )) \
+    && (( "$(date +%s)" < "$(date -d "$(/opt/bin/cfssl certinfo -cert=/var/lib/cfssl/ca.pem | jq -r '.not_after')" +%s)" - 90 * 24 * 3600 )) \
     && exit 0
 
 /opt/bin/cfssl gencert -initca ${_args} | /opt/bin/cfssljson -bare ca -

--- a/resources/cfssl-init-proxy-pki
+++ b/resources/cfssl-init-proxy-pki
@@ -16,9 +16,9 @@ fi
 [ -f proxy-ca-key.pem ] && _ca_args="-ca-key=proxy-ca-key.pem ${_ca_args}"
 
 [ -f proxy-ca-key.pem ] && [ -f proxy-ca.pem ] \
-    && (( "$(date +%s)" < "$(date -d "$(/opt/bin/cfssl certinfo -cert=/var/lib/cfssl/proxy-ca.pem | jq -r '.not_after')" +%s)" - 7 * 24 * 3600 )) \
+    && (( "$(date +%s)" < "$(date -d "$(/opt/bin/cfssl certinfo -cert=/var/lib/cfssl/proxy-ca.pem | jq -r '.not_after')" +%s)" - 90 * 24 * 3600 )) \
     || /opt/bin/cfssl gencert -initca ${_ca_args} | /opt/bin/cfssljson -bare proxy-ca -
 
 [ -f proxy-key.pem ] && [ -f proxy.pem ] \
-    && (( "$(date +%s)" < "$(date -d "$(/opt/bin/cfssl certinfo -cert=/var/lib/cfssl/proxy.pem | jq -r '.not_after')" +%s)" - 7 * 24 * 3600 )) \
+    && (( "$(date +%s)" < "$(date -d "$(/opt/bin/cfssl certinfo -cert=/var/lib/cfssl/proxy.pem | jq -r '.not_after')" +%s)" - 90 * 24 * 3600 )) \
     || /opt/bin/cfssl gencert -ca proxy-ca.pem -ca-key proxy-ca-key.pem ${_args} | /opt/bin/cfssljson -bare proxy

--- a/resources/cfssl-init-proxy-pki
+++ b/resources/cfssl-init-proxy-pki
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 _ca_args="/etc/cfssl/proxy-ca-csr.json"
 _args="/etc/cfssl/proxy-csr.json"
@@ -21,4 +21,4 @@ fi
 
 [ -f proxy-key.pem ] && [ -f proxy.pem ] \
     && (( "$(date +%s)" < "$(date -d "$(/opt/bin/cfssl certinfo -cert=/var/lib/cfssl/proxy.pem | jq -r '.not_after')" +%s)" - 90 * 24 * 3600 )) \
-    || /opt/bin/cfssl gencert -ca proxy-ca.pem -ca-key proxy-ca-key.pem ${_args} | /opt/bin/cfssljson -bare proxy
+    || /opt/bin/cfssl gencert -ca proxy-ca.pem -ca-key proxy-ca-key.pem -config=/etc/cfssl/config.json -profile=client ${_args} | /opt/bin/cfssljson -bare proxy

--- a/resources/cfssl-proxy-ca-csr.json
+++ b/resources/cfssl-proxy-ca-csr.json
@@ -3,5 +3,8 @@
         "algo": "ecdsa",
         "size": 256
     },
-    "CN": "proxyClientCA"
+    "CN": "proxyClientCA",
+    "ca": {
+        "expiry": "${ca_expiry_hours}h"
+    }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -200,13 +200,13 @@ variable "cfssl_ca_cn" {
 }
 
 variable "cfssl_ca_expiry_hours" {
-  description = "The expiry time in hours for the CA certificate (defaults to 2 years)."
-  default     = "17520"
+  description = "The expiry time in hours for the CA certificate (defaults to 10y)."
+  default     = "87600"
 }
 
 variable "cfssl_node_expiry_hours" {
-  description = "The expiry time in hours for the nodes certificats (defaults to a week)."
-  default     = "168"
+  description = "The expiry time in hours for the nodes certificats (defaults to 1y)."
+  default     = "8760"
 }
 
 variable "cfssl_node_renew_timer" {


### PR DESCRIPTION
We agreed there is little/no benefit to having shorter lifetime for the
CA or Node certificates, but increased risks having to remember all
components that rely on these certificates.

Copying default values from kubeadm:
https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#choosing-cert-validity-period
