### PR TITLE
Wait for valid hostname in node_name_command

### DIFF
--- a/_data.tf
+++ b/_data.tf
@@ -2,7 +2,7 @@ variable "node_name_command" {
   type = map(string)
 
   default = {
-    ""    = "hostname -f"
+    ""    = "until h=$(hostname -f); [ \"$h\" != \"localhost\" ] && [ \"$h\" != \"localhost.localdomain\" ]; do sleep 2; done; echo $h"
     "aws" = "/opt/bin/aws-imdsv2 local-hostname"
     "gce" = "curl -s http://metadata.google.internal/computeMetadata/v1/instance/hostname -H Metadata-Flavor:Google"
   }

--- a/resources/cfssl-new-server-cert.sh
+++ b/resources/cfssl-new-server-cert.sh
@@ -6,16 +6,7 @@ mkdir -p ${path}
 cd ${path}
 
 _ip="$(${get_ip})"
-_hostname=""
-
-%{ if get_hostname != "" ~}
 _hostname="$(${get_hostname})"
-while [ "$_hostname" = "localhost" ] || [ "$_hostname" = "localhost.localdomain" ]; do
-  echo "Waiting for hostname to be populated..."
-  sleep 2
-  _hostname="$(${get_hostname})"
-done
-%{ endif ~}
 
 _hostname_san=""
 if [ -n "$_hostname" ]; then


### PR DESCRIPTION
For non cloud providers we use "hostname -f" to get hostname, which can return "localhost" / "localhost.localdomain" early in boot. The wait loop in cfssl-new-server-cert.sh only protected server-cert generation. Other consumers (kubelet --hostname-override, control-plane-labeller, and the CN substitutions in client cert scripts) could still pick up "localhost". Move the wait into the variable so every call will now return a valid hostname.