### PR TITLE
Restore etcd hostname in cert addresses

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -43,9 +43,6 @@ data "ignition_file" "locksmithd_etcd_dropin" {
   }
 }
 
-// ETCD peer certificate (client-server). ETCD peers communicate by IP address,
-// not hostname, so only get_ip is populated. The get_hostname is empty because
-// ETCD doesn't use hostname-based peer discovery in this configuration.
 data "ignition_file" "etcd-cfssl-new-cert" {
   count = length(var.etcd_addresses)
   mode  = 493 # This is decimal for 0755 octal permissions
@@ -61,7 +58,7 @@ data "ignition_file" "etcd-cfssl-new-cert" {
       cn           = "${count.index}.etcd.${var.dns_domain}"
       org          = ""
       get_ip       = var.get_ip_command[var.cloud_provider]
-      get_hostname = ""
+      get_hostname = var.node_name_command[var.cloud_provider]
       extra_names  = join(",", ["etcd.${var.dns_domain}"])
     })
   }

--- a/resources/cfssl-server-config.json
+++ b/resources/cfssl-server-config.json
@@ -65,7 +65,7 @@
                     "client auth"
                 ],
                 "auth_key": "etcd-auth",
-                "name_whitelist": "^([0-9]+\\.etcd\\..*|etcd\\..*)$"
+                "name_whitelist": "^([0-9]+\\.etcd\\..*|etcd(-[0-9]+)?\\..*)$"
             }
         }
     },


### PR DESCRIPTION
This is needed by extrenal clients, like etcd backup job, to be able to verify connections to etcd members