### PR TITLE
Enable user namespaces

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -199,7 +199,6 @@ data "ignition_file" "sysctl_kernel_vars" {
 fs.inotify.max_user_watches=1048576
 fs.inotify.max_user_instances=8192
 vm.max_map_count=1048576
-user.max_user_namespaces=0
 EOS
   }
 }


### PR DESCRIPTION
`user.max_user_namespaces=0` was initially set as a way to mitigate [CVE-2022-0185](https://github.com/utilitywarehouse/tf_kube_ignition/commit/1c1b705272de6244a3119f2840fb5a99c1ac664d). This can now be safely removed to enable user namespaces.